### PR TITLE
make import_data idempotent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
      - "12345:5432"
   cassandra:
     image: cassandra:latest
+    volumes:
+     - "csdata:/var/lib/cassandra"
   tilerator:
     build: ./tilerator
     environment:
@@ -25,6 +27,9 @@ services:
       - "16534:16534"
   redis:
     image: redis:latest
+    command: redis-server --appendonly yes # to enable persistence
+    volumes:
+    - "redisdata:/data"
   load_db:
     build: ./load_db
     volumes:
@@ -48,3 +53,5 @@ services:
 
 volumes:
   pgdata:
+  csdata:
+  redisdata:

--- a/load_db/import_data.sh
+++ b/load_db/import_data.sh
@@ -13,6 +13,9 @@ readonly PGCONN="dbname=$database user=$user host=$host"
 echo 'importing osm data in postgres'
 mkdir -p ${MAIN_DIR}/imposm
 
+# if there is a backup schema imposm cannot delete the tables in to (with the -deployproduction, so we delete them to be able to reload the data several times
+psql -Xq -h postgres -U $user -d $database --set ON_ERROR_STOP="1" -c "drop schema backup if exists cascade;"
+
 time /usr/local/bin/imposm3 \
   import \
   -write --connection "postgis://$user@$host/$database" \
@@ -20,6 +23,7 @@ time /usr/local/bin/imposm3 \
   -diff \
   -mapping ${MAIN_DIR}/imposm3_mapping.yml \
   -deployproduction -overwritecache \
+  -optimize \
   -diffdir ${MAIN_DIR}/imposm/diff -cachedir ${MAIN_DIR}/imposm/cache
 
 # load several psql functions

--- a/load_db/import_data.sh
+++ b/load_db/import_data.sh
@@ -86,6 +86,7 @@ PGCLIENTENCODING=UTF8 ogr2ogr \
     -t_srs EPSG:3857 \
     PG:"$PGCONN" \
     ${DATA_DIR}/lake_centerline.geojson \
+    -overwrite \
     -nln "lake_centerline"
 
 # borders


### PR DESCRIPTION
this way we can import twice the data (or import, stop the docker, then
reimport)

The tile generation does not work well when the docker are stopped though :disappointed: 