### PR TITLE
change the sql to keep all osm tags

### DIFF
--- a/load_db/generated_sql.sql
+++ b/load_db/generated_sql.sql
@@ -173,19 +173,19 @@ RETURNS TABLE(geometry geometry, class text) AS $$
 $$ LANGUAGE SQL IMMUTABLE;
 DO $$ BEGIN RAISE NOTICE 'Layer waterway'; END$$;DO $$
 BEGIN
-  update osm_waterway_linestring SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry);
-  update osm_waterway_linestring_gen1 SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry);
-  update osm_waterway_linestring_gen2 SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry);
-  update osm_waterway_linestring_gen3 SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry);
+  update osm_waterway_linestring SET tags = tags || get_basic_names(tags, geometry);
+  update osm_waterway_linestring_gen1 SET tags = tags || get_basic_names(tags, geometry);
+  update osm_waterway_linestring_gen2 SET tags = tags || get_basic_names(tags, geometry);
+  update osm_waterway_linestring_gen3 SET tags = tags || get_basic_names(tags, geometry);
 END $$;
 DROP TRIGGER IF EXISTS trigger_refresh ON osm_waterway_linestring;
 
 DO $$
 BEGIN
-  update osm_waterway_linestring SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry);
-  update osm_waterway_linestring_gen1 SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry);
-  update osm_waterway_linestring_gen2 SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry);
-  update osm_waterway_linestring_gen3 SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry);
+  update osm_waterway_linestring SET tags = tags || get_basic_names(tags, geometry);
+  update osm_waterway_linestring_gen1 SET tags = tags || get_basic_names(tags, geometry);
+  update osm_waterway_linestring_gen2 SET tags = tags || get_basic_names(tags, geometry);
+  update osm_waterway_linestring_gen3 SET tags = tags || get_basic_names(tags, geometry);
 END $$;
 
 
@@ -196,7 +196,7 @@ CREATE OR REPLACE FUNCTION waterway_linestring.refresh() RETURNS trigger AS
   $BODY$
   BEGIN
     RAISE NOTICE 'Refresh waterway_linestring %', NEW.osm_id;
-    NEW.tags = slice_language_tags(NEW.tags) || get_basic_names(NEW.tags, NEW.geometry);
+    NEW.tags = NEW.tags || get_basic_names(NEW.tags, NEW.geometry);
     RETURN NEW;
   END;
   $BODY$
@@ -646,7 +646,7 @@ DROP TRIGGER IF EXISTS trigger_refresh ON mountain_peak_point.updates;
 CREATE OR REPLACE FUNCTION update_osm_peak_point() RETURNS VOID AS $$
 BEGIN
   UPDATE osm_peak_point
-  SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry)
+  SET tags = tags || get_basic_names(tags, geometry)
   WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
 
 END;
@@ -1453,7 +1453,7 @@ BEGIN
   WHERE osm.osm_id = ne.osm_id;
 
   UPDATE osm_marine_point
-  SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry)
+  SET tags = tags || get_basic_names(tags, geometry)
   WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
 
 END;
@@ -1506,7 +1506,7 @@ CREATE MATERIALIZED VIEW osm_water_lakeline AS (
 	SELECT wp.osm_id,
 		ll.wkb_geometry AS geometry,
 		name, name_en, name_de,
-		slice_language_tags(tags) || get_basic_names(tags, ll.wkb_geometry) AS tags,
+		tags || get_basic_names(tags, ll.wkb_geometry) AS tags,
 		ST_Area(wp.geometry) AS area
     FROM osm_water_polygon AS wp
     INNER JOIN lake_centerline ll ON wp.osm_id = ll.osm_id
@@ -1558,7 +1558,7 @@ CREATE MATERIALIZED VIEW osm_water_point AS (
     SELECT
         wp.osm_id, ST_PointOnSurface(wp.geometry) AS geometry,
         wp.name, wp.name_en, wp.name_de,
-        slice_language_tags(wp.tags) || get_basic_names(wp.tags, ST_PointOnSurface(wp.geometry)) AS tags,
+        wp.tags || get_basic_names(wp.tags, ST_PointOnSurface(wp.geometry)) AS tags,
         ST_Area(wp.geometry) AS area
     FROM osm_water_polygon AS wp
     LEFT JOIN lake_centerline ll ON wp.osm_id = ll.osm_id
@@ -2061,7 +2061,7 @@ DROP TRIGGER IF EXISTS trigger_refresh ON place_continent_point.updates;
 CREATE OR REPLACE FUNCTION update_osm_continent_point() RETURNS VOID AS $$
 BEGIN
   UPDATE osm_continent_point
-  SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry)
+  SET tags = tags || get_basic_names(tags, geometry)
   WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
 
 END;
@@ -2141,7 +2141,7 @@ BEGIN
   WHERE "rank" = 0;
 
   UPDATE osm_country_point
-  SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry)
+  SET tags = tags || get_basic_names(tags, geometry)
   WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
 
 END;
@@ -2194,7 +2194,7 @@ BEGIN
   UPDATE osm_island_polygon  SET geometry=ST_PointOnSurface(geometry) WHERE ST_GeometryType(geometry) <> 'ST_Point';
 
   UPDATE osm_island_polygon
-  SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry)
+  SET tags = tags || get_basic_names(tags, geometry)
   WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
 
   ANALYZE osm_island_polygon;
@@ -2243,7 +2243,7 @@ DROP TRIGGER IF EXISTS trigger_refresh ON place_island_point.updates;
 CREATE OR REPLACE FUNCTION update_osm_island_point() RETURNS VOID AS $$
 BEGIN
   UPDATE osm_island_point
-  SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry)
+  SET tags = tags || get_basic_names(tags, geometry)
   WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
 
 END;
@@ -2319,7 +2319,7 @@ BEGIN
   DELETE FROM osm_state_point WHERE "rank" IS NULL;
 
   UPDATE osm_state_point
-  SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry)
+  SET tags = tags || get_basic_names(tags, geometry)
   WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
 
 END;
@@ -2406,7 +2406,7 @@ BEGIN
   WHERE osm.osm_id = ne.osm_id;
 
   UPDATE osm_city_point
-  SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry)
+  SET tags = tags || get_basic_names(tags, geometry)
   WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
 
 END;
@@ -2619,7 +2619,7 @@ BEGIN
   WHERE station = 'subway' and subclass='station';
 
   UPDATE osm_poi_polygon
-  SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry)
+  SET tags = tags || get_basic_names(tags, geometry)
   WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
 
   ANALYZE osm_poi_polygon;
@@ -2672,7 +2672,7 @@ BEGIN
     WHERE station = 'subway' and subclass='station';
 
   UPDATE osm_poi_point
-  SET tags = slice_language_tags(tags) || get_basic_names(tags, geometry)
+  SET tags = tags || get_basic_names(tags, geometry)
   WHERE COALESCE(tags->'name:latin', tags->'name:nonlatin', tags->'name_int') IS NULL;
 
 END;


### PR DESCRIPTION
the osm tags were sliced to keep only the names, but we might want to
kepp all OSM tags to be more robust to changes

we need to see the impact on the postgres db size of this change