### PR TITLE
Use luigi pipeline to import data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ They use a mixed architecture of Kartotherian and [openmaptiles](https://github.
 
 ## "Quick" Start
 
-Use these commmands to download, import data and create tiles jobs for Luxembourg:
+Use these commmands to download, import data and create tiles jobs for Luxembourg (pbf and area defined in `load_db/import_data.sh`):
 
 (Optional) First, delete all related containers and volumes (from an older import):
 ```bash
@@ -14,11 +14,8 @@ docker-compose down -v
 ```
 Download, import and start the tiles generation:
 ```bash
-wget https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf -P data/
 docker-compose up --build -d
 docker-compose exec load_db /srv/import_data/import_data.sh
-curl -XPOST "http://localhost:16534/add?generatorId=substbasemap&storageId=basemap&zoom=7&x=66&y=43&fromZoom=0&beforeZoom=15&keepJob=true&parts=8&deleteEmpty=true"
-curl -XPOST "http://localhost:16534/add?generatorId=gen_poi&storageId=poi&zoom=7&x=66&y=43&fromZoom=14&beforeZoom=15&keepJob=true&parts=8&deleteEmpty=true"
 ```
 
 Once all tiles are generated, the map is visible on http://localhost:8585 !

--- a/load_db/Dockerfile
+++ b/load_db/Dockerfile
@@ -56,7 +56,7 @@ RUN ln -s ${MAIN_DIR}/config/external_dependencies/import-sql/language.sql ${SQL
 RUN ln -s ${MAIN_DIR}/config/external_dependencies/postgis-vt-util/postgis-vt-util.sql ${SQL_DIR}/
 
 RUN cd ${MAIN_DIR}/config/import_data \
-    && pipenv install
+    && pipenv install --system --deploy
 
 # needed for sql script, else the BOM in the file makes the query impossible
 RUN locale-gen en_US.UTF-8  

--- a/load_db/import_data.sh
+++ b/load_db/import_data.sh
@@ -16,10 +16,24 @@ psql -Xq -h $host -U $user -d $database --set ON_ERROR_STOP="1" -c "drop schema 
 psql -Xq -h $host -U $user -d $database --set ON_ERROR_STOP="1" -c "CREATE TABLE IF NOT EXISTS wd_names (id          varchar(20) UNIQUE, page          varchar(200) UNIQUE,    labels      hstore);"
 
 cd $MAIN_DIR/config/import_data
-# run the python script that loads all the data
-INVOKE_DATA_DIR=$DATA_DIR INVOKE_OSM_FILE=$osm_file pipenv run invoke
+
+# Launch import pipeline
+PYTHONPATH='.' luigi --module luigi_tasks InitialImport \
+	--importOsmConfig-import-id="initial" \
+	--importOsmConfig-pbf-url="https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf" \
+	--local-scheduler --workers=4
 
 # we tell redis that the import is finished so tilerator can start
 if [ "$REDIS_SET_KEY" = "true" ]; then
 	redis-cli -h redis set 'data_imported' 'true'
 fi
+
+# Wait for tilerator to start
+sleep 10
+
+# Generate tiles for Luxembourg
+PYTHONPATH='.' luigi --module luigi_tasks GenerateTiles \
+	--importOsmConfig-import-id="initial" \
+	--tilerator-url="http://tilerator:16534" \
+	--zoom=7 --tile-x=66 --tile-y=43 --parts=8 \
+	--local-scheduler


### PR DESCRIPTION
This replaces the call to `invoke` with a luigi pipeline defined in kartotherian_config. [See this other PR ](https://github.com/QwantResearch/kartotherian_config/pull/24)

:warning: To make it run   (as long as the config is not merged), you need to modify [**`load_db/Dockerfile`**](https://github.com/QwantResearch/kartotherian_docker/blob/useLuigiPipeline/load_db/Dockerfile#L46) and clone the **`luigiPipeline`** branch instead of `master`.
