### PR TITLE
tileview: Use node 8 to build map style

### DIFF
--- a/tileview/Dockerfile
+++ b/tileview/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-stretch as builder
+FROM node:8-stretch as builder
 
 RUN apt update && apt install -y libstdc++6
 


### PR DESCRIPTION
Node v8 is now required to run the builder.