### PR TITLE
Use netcat instead of nmap for cassandra.wait verification

### DIFF
--- a/kartotherian/Dockerfile
+++ b/kartotherian/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && \
              liblua5.2-dev \
              libgeos++-dev \
              osmctools \
-             nmap \
+             netcat \
              net-tools \
              libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++ \
              postgis && \

--- a/kartotherian/cassandra.wait
+++ b/kartotherian/cassandra.wait
@@ -4,9 +4,11 @@ CASSANDRA_SERVER=cassandra
 CASSANDRA_PORT=9042
 
 for i in `seq 1 100`; do
-    if [[ "$(nmap -p $CASSANDRA_PORT $CASSANDRA_SERVER | grep tcp | cut -d' ' -f 2)" == "open" ]]; then
+    nc -vz $CASSANDRA_SERVER $CASSANDRA_PORT
+    if [[ "$?" == "0" ]]; then
         exit 0
     fi
     sleep 1
 done
+
 exit 1

--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update && \
              libgeos++-dev \
              osmctools \
              nmap \
+             netcat \
              postgis \
              redis-tools \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/tilerator/runserver.sh
+++ b/tilerator/runserver.sh
@@ -2,7 +2,22 @@
 set -e
 
 # wait for cassandra to be up
-/usr/local/bin/cassandra.wait
+CASSANDRA_SERVER=cassandra
+CASSANDRA_PORT=9042
+
+function wait_for_cassandra() {
+    for i in `seq 1 100`; do
+        nc -vz $CASSANDRA_SERVER $CASSANDRA_PORT
+        if [[ "$?" == "0" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+    # cassandra unreachable, exiting
+    exit 1
+}
+
+wait_for_cassandra
 
 # wait for the database to be loaded
 while true; do


### PR DESCRIPTION
Simple verification to check if Cassandra port is open using netcat instead of nmap.