### PR TITLE
generate tiles as part of the load_db script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # kartotherian_docker
+
 docker images for the [kartotherian project](https://github.com/kartotherian/kartotherian)
 
 They use a mixed architecture of Kartotherian and [openmaptiles](https://github.com/openmaptiles/openmaptiles)
-
 
 ## "Quick" Start for local testing
 
@@ -18,14 +18,10 @@ Download, import and start the tiles generation:
 
 ```bash
 docker-compose -f docker-compose.yml -f local-compose.yml up --build -d
-docker-compose -f docker-compose.yml -f local-compose.yml run --rm -e INVOKE_OSM_URL=https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf load_db
-
-curl -XPOST "http://localhost:16534/add?generatorId=substbasemap&storageId=basemap&zoom=7&x=66&y=43&fromZoom=0&beforeZoom=15&keepJob=true&parts=8&deleteEmpty=true"
-curl -XPOST "http://localhost:16534/add?generatorId=gen_poi&storageId=poi&zoom=7&x=66&y=43&fromZoom=14&beforeZoom=15&keepJob=true&parts=8&deleteEmpty=true"
+docker-compose -f docker-compose.yml -f local-compose.yml run --rm -e INVOKE_OSM_URL=https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf -e INVOKE_TILES_X=66 -e INVOKE_TILES_Y=43 -e INVOKE_TILES_Z=7 load_db
 ```
 
 Once all tiles are generated, the map is visible on http://localhost:8585 !
-
 
 ## running
 
@@ -37,9 +33,9 @@ To launch kartotherian just do:
 
 ### Import in Postgres
 
-to download a pbf and load data in postgres you need:
+to download a pbf and load data in postgres and generate tiles you need:
 
-`docker-compose run --rm -e INVOKE_OSM_URL=https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf load_db`
+`docker-compose run --rm -e INVOKE_OSM_URL=https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf -e INVOKE_TILES_X=66 -e INVOKE_TILES_Y=43 -e INVOKE_TILES_Z=7 load_db`
 
 The different way to configure the import can be seen in the [script repository](https://github.com/QwantResearch/kartotherian_config/blob/master/import_data)
 
@@ -66,17 +62,13 @@ Note: even if the local directoy in `./data` the osm file path is "/data/**input
 
 ### Tiles generation
 
-After this you need to generate the tiles. You can do it either by generating all the tiles with:
-`docker exec -it kartotheriandocker_tilerator_1 /gen_tiles.sh`
+The tiles generation is also handle by the `load_db` container.
 
-or only a subset using the api. `x` & `y` are based on the [Slippy Map Tile name](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) system and you can use [Geofabrik's tool](http://download.geofabrik.de/europe/luxembourg.html) to generate these for a specific location.
-For example to generate the tiles from 7 to 16 zoom level only for Luxembourg:
+To only generate 1 tile, you can set `INVOKE_TILES_X`, `INVOKE_TILES_Y`, `INVOKE_TILES_Z`. x, y, and z are based on the [Slippy Map Tile name](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) system and you can use [Geofabrik's tool](http://download.geofabrik.de/europe/luxembourg.html) to generate these for a specific location.
 
-`curl -XPOST "http://localhost:16534/add?generatorId=substbasemap&storageId=basemap&zoom=7&x=66&y=43&fromZoom=7&beforeZoom=15&keepJob=true&parts=8&deleteEmpty=true"`
+The different ways to configure the tiles generation can be seen [in the default configuration file](https://github.com/QwantResearch/kartotherian_config/blob/master/import_data/invoke.yaml).
 
-`curl -XPOST "http://localhost:16534/add?generatorId=gen_poi&storageId=poi&zoom=7&x=66&y=43&fromZoom=7&beforeZoom=15&keepJob=true&parts=8&deleteEmpty=true"`
-
-You can check the tile generation at `http://localhost:16534/jobs` and check a vector tile based map on `http://localhost:8585`
+If you have forwarded the port, you can check the tile generation at `http://localhost:16534/jobs` and check a vector tile based map on `http://localhost:8585`
 
 ## archi
 

--- a/kartotherian/Dockerfile
+++ b/kartotherian/Dockerfile
@@ -28,7 +28,7 @@ ADD https://api.github.com/repos/QwantResearch/kartotherian/git/refs/heads/maste
 RUN git clone https://github.com/QwantResearch/kartotherian.git /opt/kartotherian \
     && git clone https://github.com/QwantResearch/kartotherian_config.git /opt/kartotherian_config \
     && cd /opt/kartotherian_config \
-    && git checkout 8bc03376c2 \
+    && git checkout 30bf6e8ce894 \
     && cd /opt/kartotherian && npm install --production && npm dedupe
 
 # .xml style is overridden to use system fonts (DejaVu instead of Arial)

--- a/load_db/Dockerfile
+++ b/load_db/Dockerfile
@@ -36,7 +36,7 @@ RUN apt update && \
 
 RUN git clone https://github.com/QwantResearch/kartotherian_config.git ${MAIN_DIR}/config \
     && cd ${MAIN_DIR}/config \
-    && git checkout 8bc03376c2
+    && git checkout 30bf6e8ce894
 RUN cd ${MAIN_DIR}/config && git submodule update --init
 RUN ln -s ${MAIN_DIR}/config/imposm/generated_mapping_base.yaml ${MAIN_DIR}/generated_mapping_base.yaml
 RUN ln -s ${MAIN_DIR}/config/imposm/generated_mapping_poi.yaml ${MAIN_DIR}/generated_mapping_poi.yaml

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -4,7 +4,7 @@ services:
 
   tilerator:
     ports:
-      - "16534:16534"  # for the moment we need tilerator port, but we'll be able to remove this when the tilegen will be handle by the python script
+      - "16534:80"
 
   kartotherian:
     ports:

--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -30,7 +30,7 @@ RUN git clone -b master https://github.com/QwantResearch/tilerator.git /opt/tile
 
 RUN git clone https://github.com/QwantResearch/kartotherian_config.git /opt/kartotherian_config \
     && cd /opt/kartotherian_config \
-    && git checkout 8bc03376c2
+    && git checkout 30bf6e8ce894
 
 COPY variables.yaml /opt/tilerator
 COPY config.yaml /opt/tilerator

--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 ENV NODE_PATH='/opt/tilerator/node_modules' \
-    TILERATOR_PORT=16354
+    TILERATOR_PORT=80
 
 RUN apt update && \
     apt install -y \

--- a/tilerator/config.yaml
+++ b/tilerator/config.yaml
@@ -32,7 +32,7 @@ services:
     # version: ^0.4.0
     # per-service config
     conf:
-      port: 16534
+      port: 80
 
       # restrict to localhost access only
       # interface: '*'


### PR DESCRIPTION
note: tilerator now use the default port, so the docker-compose url ofr
it is onlye `http://tilerator`

needs https://github.com/QwantResearch/kartotherian_config/pull/30 (and thus after the config PR merge, we need to update the kartotherian_config sha1 used)