### PR TITLE
Split tilerator into two services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,17 @@ services:
       - cassandra
       - postgres
       - redis
+    environment:
+      - TILERATOR_MODE=api # This service will not process tiles
     volumes:
       - update_tiles_data:/data/update_tiles_data
+
+  tilerator-worker:
+    build: ./tilerator
+    depends_on:
+      - cassandra
+      - postgres
+      - redis
 
   redis:
     image: redis:latest

--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -31,8 +31,8 @@ RUN git clone https://github.com/QwantResearch/kartotherian_config.git /opt/kart
     && cd /opt/kartotherian_config \
     && git checkout 738abe8c1060ef104be379087612b3a5b6348cfe
 
-COPY variables.yaml /opt/tilerator
-COPY config.yaml /opt/tilerator
+COPY variables.yaml /opt/tilerator/
+COPY config*.yaml /opt/tilerator/
 COPY gen_tiles.sh /gen_tiles.sh
 
 RUN mkdir -p /etc/tilerator
@@ -42,7 +42,7 @@ RUN ln -sf /opt/kartotherian_config/tilerator/data_tm2source_lite.yml /etc/tiler
 
 RUN chmod +x /gen_tiles.sh \
     && chmod 600 /opt/tilerator/variables.yaml \
-    && ln -sf /opt/tilerator/config.yaml /etc/tilerator \
+    && ln -sf /opt/tilerator/config*.yaml /etc/tilerator \
     && ln -sf /opt/tilerator/variables.yaml /etc/tilerator \
     && ln -sf /opt/kartotherian_config/tilerator/sources.yaml /etc/tilerator \
     && ln -sf /opt/tilerator/dist/init-scripts/cassandra.wait /usr/local/bin

--- a/tilerator/config.api.yaml
+++ b/tilerator/config.api.yaml
@@ -1,0 +1,87 @@
+# Number of worker processes to spawn.
+# Set to 0 to run everything in a single process without clustering.
+# Use 'ncpu' to run as many workers as there are CPU units
+num_workers: ncpu
+
+# Log error messages and gracefully restart a worker if v8 reports that it
+# uses more heap (note: not RSS) than this many mb.
+worker_heap_limit_mb: 250
+
+# Logger info
+logging:
+  level: info
+  streams:
+    - type: debug
+#  streams:
+#  # Use gelf-stream -> logstash
+#  - type: gelf
+#    host: logstash1003.eqiad.wmnet
+#    port: 12201
+
+# Statsd metrics reporter
+metrics:
+  #type: log
+  #host: localhost
+  #port: 8125
+
+services:
+  - name: tilerator
+    # a relative path or the name of an npm package, if different from name
+    module: ./app.js
+    # optionally, a version constraint of the npm package
+    # version: ^0.4.0
+    # per-service config
+    conf:
+      port: 80
+
+      # restrict to localhost access only
+      # interface: '*'
+
+      # more per-service config settings
+      # the location of the spec, defaults to spec.yaml if not specified
+      spec: /opt/tilerator/spec.template.yaml
+      # allow cross-domain requests to the API (default '*')
+      cors: '*'
+      # to disable use:
+      # cors: false
+      # to restrict to a particular domain, use:
+      # cors: restricted.domain.org
+      # content for the CSP headers
+      # csp: false  # uncomment this line to disable sending them
+      # URL of the outbound proxy to use (complete with protocol)
+      # proxy: http://my.proxy.org:8080
+      # the list of domains for which not to use the proxy defined above
+      # no_proxy_list:
+      #   - domain1.com
+      #   - domain2.org
+      # the list of incoming request headers that can be logged; if left empty,
+      # the following headers are allowed: cache-control, content-length,
+      # content-type, if-match, user-agent, x-request-id
+      # log_header_whitelist:
+      #   - cache-control
+      #   - content-length
+      #   - content-type
+      #   - if-match
+      #   - user-agent
+      #   - x-request-id
+
+      sources: /etc/tilerator/sources.yaml
+      variables: /etc/tilerator/variables.yaml
+
+      modules:
+      - "@kartotherian/cassandra"
+      - "@kartotherian/overzoom"
+      - "@kartotherian/substantial"
+      - "@kartotherian/tilelive-tmsource"
+
+      # If true, do not enable admin interface
+      daemonOnly: false
+
+      # If true, runs this instance without processing tiles
+      # This could be good for queue management
+      uiOnly: true
+
+      redis: {
+        'host': 'redis',
+        'port': 6379
+      }

--- a/tilerator/config.worker.yaml
+++ b/tilerator/config.worker.yaml
@@ -75,7 +75,7 @@ services:
       - "@kartotherian/tilelive-tmsource"
 
       # If true, do not enable admin interface
-      daemonOnly: false
+      daemonOnly: true
 
       # If true, runs this instance without processing tiles
       # This could be good for queue management

--- a/tilerator/runserver.sh
+++ b/tilerator/runserver.sh
@@ -5,6 +5,14 @@ set -e
 CASSANDRA_SERVER=cassandra
 CASSANDRA_PORT=9042
 
+TILERATOR_MODE="${TILERATOR_MODE:-default}"
+
+if [[ "$TILERATOR_MODE" == "api" ]]; then
+    TILERATOR_CONFIG_FILE=config.api.yaml
+else
+    TILERATOR_CONFIG_FILE=config.yaml
+fi
+
 function wait_for_cassandra() {(
     set +e
     for i in `seq 1 100`; do
@@ -20,6 +28,6 @@ function wait_for_cassandra() {(
 
 wait_for_cassandra
 
-/usr/bin/nodejs /opt/tilerator/server.js -c /etc/tilerator/config.yaml
+/usr/bin/nodejs /opt/tilerator/server.js -c /etc/tilerator/$TILERATOR_CONFIG_FILE
 
 sleep infinity

--- a/tilerator/runserver.sh
+++ b/tilerator/runserver.sh
@@ -5,12 +5,12 @@ set -e
 CASSANDRA_SERVER=cassandra
 CASSANDRA_PORT=9042
 
-TILERATOR_MODE="${TILERATOR_MODE:-default}"
+TILERATOR_MODE="${TILERATOR_MODE:-worker}"
 
 if [[ "$TILERATOR_MODE" == "api" ]]; then
     TILERATOR_CONFIG_FILE=config.api.yaml
 else
-    TILERATOR_CONFIG_FILE=config.yaml
+    TILERATOR_CONFIG_FILE=config.worker.yaml
 fi
 
 function wait_for_cassandra() {(


### PR DESCRIPTION
* `tilerator` will run the API with `uiOnly: true` and will receive jobs requests from load_db service. Default config in kartotherian_config remain unchanged, the API is still accessible via "http://tilerator"
* `tilerator-worker` will launch workers and process tiles, and do not depend on any volume