### PR TITLE
Pin Dockerfile base images

### DIFF
--- a/kartotherian/Dockerfile
+++ b/kartotherian/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-stretch
+FROM node:6-stretch@sha256:9b5d8caed98111c7bcacd8c46bce19635670b04d59dba20f765b096d6ef98dea
 
 ENV NODE_ENV=production
 

--- a/load_db/Dockerfile
+++ b/load_db/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-stretch
+FROM python:3.6-stretch@sha256:bccbebc715c9b0c0bf247ba3781248c1b0d075d5ef462ee86a396a394a19f6b0
 
 
 ENV MAIN_DIR=/srv/import_data \

--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:16.04@sha256:45ddfa61744947b0b8f7f20b8de70cbcdd441a6a0532f791fd4c09f5e491a8eb
 
 ENV NODE_PATH='/opt/tilerator/node_modules' \
     TILERATOR_PORT=80


### PR DESCRIPTION
Use sha256 in Dockerfile base images for `kartotherian`, `tilerator`, and `load_db`.