### PR TITLE
expose prometheus metrics from kartotherian

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,11 +56,6 @@ services:
 
   telegraf:
     build: ./telegraf
-    
-  prometheus:
-    image: prom/prometheus
-    ports:
-      - 9090:9090
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,11 +54,8 @@ services:
   kartotherian:
     build: ./kartotherian
 
-  statsd-exporter:
-    image: prom/statsd-exporter
-    ports:
-      - 9102:9102
-      - 9125/udp
+  telegraf:
+    build: ./telegraf
     
   prometheus:
     image: prom/prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,17 @@ services:
   kartotherian:
     build: ./kartotherian
 
+  statsd-exporter:
+    image: prom/statsd-exporter
+    ports:
+      - 9102:9102
+      - 9125/udp
+    
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - 9090:9090
+
 volumes:
   pgdata:
   cassandra_data:

--- a/kartotherian/config.yaml
+++ b/kartotherian/config.yaml
@@ -11,6 +11,13 @@ worker_heap_limit_mb: 250
 logging:
   level: info
 
+
+# Statsd metrics reporter
+metrics:
+  type: debug
+  host: statsd-exporter
+  port: 9125
+
 services:
   - name: kartotherian
     module: ./app.js

--- a/kartotherian/config.yaml
+++ b/kartotherian/config.yaml
@@ -15,8 +15,8 @@ logging:
 # Statsd metrics reporter
 metrics:
   type: debug
-  host: statsd-exporter
-  port: 9125
+  host: telegraf
+  port: 8125
 
 services:
   - name: kartotherian

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -22,6 +22,11 @@ services:
     ports:
       - "8585:3000"
 
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - 9090:9090
+
 volumes:
   input_data:
     driver_opts:

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -22,11 +22,6 @@ services:
     ports:
       - "8585:3000"
 
-  prometheus:
-    image: prom/prometheus
-    ports:
-      - 9090:9090
-
 volumes:
   input_data:
     driver_opts:

--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -1,0 +1,3 @@
+FROM telegraf:alpine
+
+COPY telegraf.conf /etc/telegraf/telegraf.conf

--- a/telegraf/readme.md
+++ b/telegraf/readme.md
@@ -1,0 +1,3 @@
+Telegraf used to get kartotherian's stats (sent to statsd) and expose prometheus metrics
+
+It runs a statsd instance on the port `:8125` and expose prometheus metrics on `:9273/metrics`

--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -1,0 +1,19 @@
+[[inputs.statsd]]
+  protocol = "udp"
+  service_address = ":8125"
+  percentiles = [99, 90, 50]
+
+# Publish all metrics to /metrics for Prometheus to scrape
+[[outputs.prometheus_client]]
+  ## Address to listen on.
+  listen = ":9273"
+
+  ## Path to publish the metrics on.
+  # path = "/metrics"
+
+  ## Expiration interval for each metric. 0 == no expiration
+  # expiration_interval = "60s"
+
+  ## Send string metrics as Prometheus labels.
+  ## Unless set to false all string metrics will be sent as labels.
+  # string_as_label = true

--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -12,7 +12,7 @@
   # path = "/metrics"
 
   ## Expiration interval for each metric. 0 == no expiration
-  # expiration_interval = "60s"
+  expiration_interval = "120s"
 
   ## Send string metrics as Prometheus labels.
   ## Unless set to false all string metrics will be sent as labels.


### PR DESCRIPTION
This PR is not to merge as is, it's a POC to show how to get prometheus metrics from kartotherian.

it uses telegraf to work as a statsd intance and expose prometheus metrics from it.

for the grafana dashboards, we can do something like [wikimedia is doing](https://grafana.wikimedia.org/dashboard/db/service-kartotherian?refresh=5m&orgId=1).

the metrics are (in debug):
 * some metrics about the heap
 * duration to get tiles, ventilated by layer and zoom level :heart_eyes: 

we now need to check with our CI that this system is ok for them