### PR TITLE
Update configuration for resilience

### DIFF
--- a/kartotherian/Dockerfile
+++ b/kartotherian/Dockerfile
@@ -12,7 +12,7 @@ USER node
 
 RUN git clone https://github.com/QwantResearch/kartotherian.git /opt/kartotherian \
     && cd /opt/kartotherian \
-    && git checkout 0851c0b80995f07c9b46aa8308f2a3c2b8d734b8 \
+    && git checkout 832d99f14a8876fce07063ed63257f50a60014b0 \
     && npm install --production \
     && git clone https://github.com/QwantResearch/kartotherian_config.git /opt/kartotherian_config \
     && cd /opt/kartotherian_config \

--- a/kartotherian/config.yaml
+++ b/kartotherian/config.yaml
@@ -51,3 +51,6 @@ services:
 
       # Expose source 'info.json' (default: true)
       exposeSourceInfo: false
+
+      # Catch and log statsd errors (default: false)
+      catchMetricsErrors: true

--- a/tilerator/config.api.yaml
+++ b/tilerator/config.api.yaml
@@ -7,6 +7,8 @@ num_workers: '{env(TILERATOR_NUM_WORKERS,ncpu)}'
 # uses more heap (note: not RSS) than this many mb.
 worker_heap_limit_mb: 250
 
+worker_heartbeat_timeout: '{env(TILERATOR_WORKER_HEARTBEAT_TIMEOUT,7500)}'
+
 # Logger info
 logging:
   level: info

--- a/tilerator/config.worker.yaml
+++ b/tilerator/config.worker.yaml
@@ -7,6 +7,8 @@ num_workers: '{env(TILERATOR_NUM_WORKERS,ncpu)}'
 # uses more heap (note: not RSS) than this many mb.
 worker_heap_limit_mb: 250
 
+worker_heartbeat_timeout: '{env(TILERATOR_WORKER_HEARTBEAT_TIMEOUT,30000)}'
+
 # Logger info
 logging:
   level: info


### PR DESCRIPTION
* Kartotherian: set `catchMetricsErrors` to prevent worker restart on statsd errors
  Following https://github.com/QwantResearch/kartotherian/pull/6

* Tilerator:  
    * Read heartbeat timeout from environment
    * Default to 30s on tilerator-worker. A worker could be slow to initialize in some cases (eg when all workers are starting simultaneously and all connections to source databases need to be reset)