### PR TITLE
Add travis configuration for docker images automatic builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
     - SERVICE=kartotherian
     - SERVICE=telegraf
 
+branches:
+  only:
+    - master
 
 before_install:
   - echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+services:
+  - docker
+
+env:
+  global:
+    - DOCKER_IMAGE_PREFIX=qwantresearch/kartotherian
+  matrix:
+    - SERVICE=load_db
+    - SERVICE=tilerator
+    - SERVICE=kartotherian
+    - SERVICE=telegraf
+
+
+before_install:
+  - echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+script:
+  - export DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}_$SERVICE"
+  - docker build --label "org.label-schema.vcs-ref=$TRAVIS_COMMIT" -t $DOCKER_IMAGE ./$SERVICE
+  - docker push $DOCKER_IMAGE

--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -1,3 +1,3 @@
-FROM telegraf:alpine
+FROM telegraf:1.8-alpine@sha256:7f6873f5745fe9b4f610c5dcfaaa73d7cd75adb63bd770bb70c26a7e85c94a2a
 
 COPY telegraf.conf /etc/telegraf/telegraf.conf


### PR DESCRIPTION
4 images will be built automatically on master branch:
 * `qwantresearch/kartotherian_load_db`
 * `qwantresearch/kartotherian_tilerator`
 * `qwantresearch/kartotherian_kartotherian`
 * `qwantresearch/kartotherian_telegraf`
