### PR TITLE
Build PRs but don't push if not master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ env:
     - SERVICE=kartotherian
     - SERVICE=telegraf
 
-branches:
-  only:
-    - master
-
 before_install:
-  - echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+    echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+    fi
 
 script:
   - export DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}_$SERVICE"
   - docker build --label "org.label-schema.vcs-ref=$TRAVIS_COMMIT" -t $DOCKER_IMAGE ./$SERVICE
-  - docker push $DOCKER_IMAGE
+  - if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+    docker push $DOCKER_IMAGE;
+    fi


### PR DESCRIPTION
This change comes in mostly because of #76 (even though it could have come in any other time). It adds check for all branches and prevent push if not on master branch and remove docker log in if not on master branch as well.