### PR TITLE
Improve robustness of import and update jobs

### DIFF
--- a/import_data/osm_update.sh
+++ b/import_data/osm_update.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -x
+set -o pipefail
 
 description="OpenStreetMap database update script"
 version="0.2/20180716"

--- a/import_data/tasks.py
+++ b/import_data/tasks.py
@@ -58,22 +58,25 @@ def _wait_until_postgresql_is_ready(ctx):
 def prepare_db(ctx):
     _wait_until_postgresql_is_ready(ctx)
     """
-    creates the import database and remove the old backup one
+    create the import database and remove the old backup one
     """
-    _execute_sql(ctx, f"DROP DATABASE IF EXISTS {ctx.pg.backup_database};")
-    if not _db_exists(ctx, ctx.pg.import_database):
-        logging.info("creating databases")
-        _execute_sql(ctx, f"CREATE DATABASE {ctx.pg.import_database};")
-        _execute_sql(
-            ctx,
-            db=ctx.pg.import_database,
-            sql=f"""
+    _execute_sql(ctx, f"DROP DATABASE IF EXISTS {ctx.pg.import_database};")
+
+    logging.info(f"creating {ctx.pg.import_database} database")
+    _execute_sql(ctx, f"CREATE DATABASE {ctx.pg.import_database};")
+    _execute_sql(
+        ctx,
+        db=ctx.pg.import_database,
+        sql="""
 CREATE EXTENSION postgis;
 CREATE EXTENSION hstore;
 CREATE EXTENSION unaccent;
 CREATE EXTENSION fuzzystrmatch;
 CREATE EXTENSION osml10n;""",
-        )
+    )
+
+    _execute_sql(ctx, f"DROP DATABASE IF EXISTS {ctx.pg.backup_database};")
+
 
 
 def _read_md5(md5_response):


### PR DESCRIPTION
* Remove pre-existing import database (eg, from a previous job that failed)
* Fail on first imposm error in osm_update (errors from piped command used to be ignored)