### PR TITLE
Use kartotherian monorepo to build tilerator and kartotherian images

### DIFF
--- a/kartotherian/Dockerfile
+++ b/kartotherian/Dockerfile
@@ -12,17 +12,14 @@ USER node
 
 RUN git clone https://github.com/QwantResearch/kartotherian.git /opt/kartotherian \
     && cd /opt/kartotherian \
-    && git checkout 98338d934057426fb3ac938b0e00c6dee533efc3 \
+    && git checkout b932ee3254e72aeea6af5935fd53e4269807a86c \
     && npm install --production
 
-COPY --chown=node kartotherian/config.yaml /opt/kartotherian
-
-RUN mkdir -p /etc/kartotherian \
-    && ln -sf /opt/kartotherian/config.yaml /etc/kartotherian
+COPY kartotherian/config.yaml /etc/kartotherian
 COPY kartotherian/sources.yaml /etc/kartotherian
 
 ENV KARTOTHERIAN_CASSANDRA_SERVERS=cassandra
 ENV KARTOTHERIAN_CASSANDRA_USER=gis
 ENV KARTOTHERIAN_CASSANDRA_PSWD=
 
-CMD node /opt/kartotherian/server.js -c /etc/kartotherian/config.yaml
+CMD node /opt/kartotherian/packages/kartotherian/server.js -c /etc/kartotherian/config.yaml

--- a/kartotherian/config.yaml
+++ b/kartotherian/config.yaml
@@ -20,7 +20,7 @@ metrics:
 
 services:
   - name: kartotherian
-    module: ./app.js
+    module: kartotherian
 
     conf:
       port: 6533

--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -41,10 +41,10 @@ ENV LC_ALL C.UTF-8
 RUN cd /opt/openmaptiles \
     && CONFIG_DIR=/opt/config make qwant
 
+RUN mkdir -p /etc/tilerator
 COPY tilerator/config*.yaml /etc/tilerator/
 COPY tilerator/gen_tiles.sh /gen_tiles.sh
 
-RUN mkdir -p /etc/tilerator
 COPY tilerator/sources.yaml /etc/tilerator/
 RUN ln -sf /opt/config/tilerator/data_tm2source_base.yml /etc/tilerator
 RUN ln -sf /opt/config/tilerator/data_tm2source_poi.yml /etc/tilerator

--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get update && \
         locales \
     && npm i npm@latest -g
 
-RUN git clone https://github.com/QwantResearch/tilerator.git /opt/tilerator \
-    && cd /opt/tilerator \
-    && git checkout 64b69c064aae15d474bd61da2c6bc35140f118f8 \
+RUN git clone https://github.com/QwantResearch/kartotherian.git /opt/kartotherian \
+    && cd /opt/kartotherian \
+    && git checkout b932ee3254e72aeea6af5935fd53e4269807a86c \
     && npm install --production
 
 # install openmaptiles-tools
@@ -41,7 +41,7 @@ ENV LC_ALL C.UTF-8
 RUN cd /opt/openmaptiles \
     && CONFIG_DIR=/opt/config make qwant
 
-COPY tilerator/config*.yaml /opt/tilerator/
+COPY tilerator/config*.yaml /etc/tilerator/
 COPY tilerator/gen_tiles.sh /gen_tiles.sh
 
 RUN mkdir -p /etc/tilerator
@@ -50,9 +50,7 @@ RUN ln -sf /opt/config/tilerator/data_tm2source_base.yml /etc/tilerator
 RUN ln -sf /opt/config/tilerator/data_tm2source_poi.yml /etc/tilerator
 RUN ln -sf /opt/config/tilerator/data_tm2source_lite.yml /etc/tilerator
 
-RUN chmod +x /gen_tiles.sh \
-    && ln -sf /opt/tilerator/config*.yaml /etc/tilerator \
-    && ln -sf /opt/tilerator/dist/init-scripts/cassandra.wait /usr/local/bin
+RUN chmod +x /gen_tiles.sh
 
 COPY tilerator/runserver.sh /runserver.sh
 RUN chmod +x /runserver.sh

--- a/tilerator/config.api.yaml
+++ b/tilerator/config.api.yaml
@@ -29,7 +29,7 @@ metrics:
 services:
   - name: tilerator
     # a relative path or the name of an npm package, if different from name
-    module: ./app.js
+    module: tilerator
     # optionally, a version constraint of the npm package
     # version: ^0.4.0
     # per-service config
@@ -41,7 +41,7 @@ services:
 
       # more per-service config settings
       # the location of the spec, defaults to spec.yaml if not specified
-      spec: /opt/tilerator/spec.template.yaml
+      spec: /opt/kartotherian/packages/tilerator/spec.template.yaml
       # allow cross-domain requests to the API (default '*')
       cors: '*'
       # to disable use:

--- a/tilerator/config.worker.yaml
+++ b/tilerator/config.worker.yaml
@@ -29,7 +29,7 @@ metrics:
 services:
   - name: tilerator
     # a relative path or the name of an npm package, if different from name
-    module: ./app.js
+    module: tilerator
     # optionally, a version constraint of the npm package
     # version: ^0.4.0
     # per-service config

--- a/tilerator/gen_tiles.sh
+++ b/tilerator/gen_tiles.sh
@@ -6,7 +6,7 @@
 set -e
 set +x
 
-node /opt/tilerator/scripts/tileshell.js \
+node /opt/kartotherian/packages/tilerator/scripts/tileshell.js \
 	--config /etc/tilerator/config.yaml \
 	--source /etc/tilerator/sources.yaml \
 	-j.zoom 0 -j.fromZoom 0 -j.beforeZoom 11 \
@@ -14,7 +14,7 @@ node /opt/tilerator/scripts/tileshell.js \
 	-j.parts 8 -j.deleteEmpty -j.keepJob \
 	-j.checkZoom "-1"
 
-node /opt/tilerator/scripts/tileshell.js \
+node /opt/kartotherian/packages/tilerator/scripts/tileshell.js \
 	--config /etc/tilerator/config.yaml \
 	--source /etc/tilerator/sources.yaml \
 	-j.zoom 0 -j.fromZoom 0 -j.beforeZoom 11 \

--- a/tilerator/runserver.sh
+++ b/tilerator/runserver.sh
@@ -28,4 +28,4 @@ function wait_for_cassandra() {(
 
 wait_for_cassandra
 
-node /opt/tilerator/server.js -c /etc/tilerator/$TILERATOR_CONFIG_FILE
+node /opt/kartotherian/packages/tilerator/server.js -c /etc/tilerator/$TILERATOR_CONFIG_FILE


### PR DESCRIPTION
Following https://github.com/QwantResearch/kartotherian/pull/8

* Update Dockerfile for `kartotherian` and `tilerator`
* Update paths to subpackages
* Remove unnecessary symlinks for config files

