### PR TITLE
Replace 'osmosis' with 'osmupdate' to fetch change files

### DIFF
--- a/import_data/invoke.yaml
+++ b/import_data/invoke.yaml
@@ -60,6 +60,4 @@ tiles:
     storage: poi
 
 osm_update:
-  replication_url: https://planet.osm.org/replication/day
-  max_interval: 0 # maximum delay to catch up (in seconds) by osmosis, 0 to fetch all changes
-  max_interations: 300 # maximum number of requests to replication server to find the correct state file
+  replication_url: https://planet.osm.org/replication

--- a/import_data/tasks.py
+++ b/import_data/tasks.py
@@ -5,15 +5,9 @@ import os
 import os.path
 import time
 from datetime import timedelta, datetime
-from urllib.request import getproxies
-from urllib.parse import urlparse
-
 import requests
-import configparser
 from invoke import task
 from invoke.exceptions import Failure
-from pydantic import BaseModel
-from pydantic.datetime_parse import parse_datetime
 from utils.lock import FileLock
 
 
@@ -649,7 +643,7 @@ def run_osm_update(ctx):
     with FileLock(lock_path) as lock:
         current_osm_timestamp = read_current_state(ctx)
         try:
-            result = ctx.run(
+            ctx.run(
                 f'osmupdate -v --day --hour --base-url={ctx.osm_update.replication_url} '
                 f'{current_osm_timestamp} {change_file_path}'
             )

--- a/load_db/Dockerfile
+++ b/load_db/Dockerfile
@@ -3,20 +3,16 @@ FROM python:3.6-stretch@sha256:bccbebc715c9b0c0bf247ba3781248c1b0d075d5ef462ee86
 ENV MAIN_DIR=/srv/import_data
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
         git \
         unzip \
         curl \
-        libpq-dev \
-        libproj-dev \
-        liblua5.2-dev \
-        libgeos++-dev \
         osmctools \
-        sqlite3 \
         gdal-bin \
         postgis \
-        osmosis \
+        postgresql-client \
         jq \
+    && rm -rf /var/lib/apt/lists/* \
 # install imposm 0.8.1 (custom release, waiting for https://github.com/omniscale/imposm3/pull/206 to be merged)
     && wget https://github.com/amatissart/imposm3/releases/download/v0.8.1-qwant-0/imposm-0.8.1-qwant-0-linux-x86-64.tar.gz \
     && tar xvfz imposm-0.8.1-qwant-0-linux-x86-64.tar.gz \
@@ -36,9 +32,7 @@ COPY load_db/config_base.json ${MAIN_DIR}/imposm/
 COPY load_db/config_poi.json ${MAIN_DIR}/imposm/
 
 # needed for sql script, else the BOM in the file makes the query impossible
-RUN locale-gen en_US.UTF-8
 ENV LANG C.UTF-8
-ENV LANGUAGE en_US:en
 ENV LC_ALL C.UTF-8
 
 RUN cd ${MAIN_DIR}/import_data \


### PR DESCRIPTION
Another step to make osm updates more robust.

## Why

In some cases, osmosis fails to parse OSM change files because of a bug in its parsing library.
See https://github.com/openstreetmap/osmosis/pull/50 for more details.

Osmosis is no longer maintained. So it seems more reasonable to switch to [`osmupdate`](https://wiki.openstreetmap.org/wiki/Osmupdate), provided by `osmctools` package.

## Implementation

This change also makes the implementation simpler: no more `JAVACMD_OPTIONS` to override, no more `configuration.txt` file to maintain. And it's no longer required to keep a `sequenceNumber` in the state file.

Osmupdate will simply fetch all changes from OSM servers, based on the **`timestamp`** that is present in `state.txt`. This file (already used by osmosis) keeps track of the latest change file that is applied on the database.

