### PR TITLE
Define metrics prefix for kartotherian

### DIFF
--- a/kartotherian/config.yaml
+++ b/kartotherian/config.yaml
@@ -14,6 +14,7 @@ logging:
 
 # Statsd metrics reporter
 metrics:
+  name: kartotherian
   type: debug
   host: telegraf
   port: 8125


### PR DESCRIPTION
For compatibility with metrics published by telegraf.

It seems that the new version of service-runner (used by kartotherian) defines "root" as the default prefix.