### PR TITLE
parallelize import

### DIFF
--- a/import_data/invoke.yaml
+++ b/import_data/invoke.yaml
@@ -26,11 +26,13 @@ border:
   osmborder_lines_url: https://github.com/openmaptiles/openmaptiles-tools/releases/download/v3.0.0-beta/osmborder_lines.csv.gz
 
 osm:
-  ## one of those value needs to be configured
+  ## one of 'url' or 'file' needs to be configured
   ## URL where to get the osm file
   url:
   ## Path of the file
   file:
+  # Fetch and apply updates on .pbf file before importing
+  update_pbf: True
 
 # Toggle import of statistics and metadata from Wikidata
 wikidata:

--- a/import_data/tasks/format_stdout.py
+++ b/import_data/tasks/format_stdout.py
@@ -1,0 +1,56 @@
+import sys
+from functools import wraps
+
+from invoke import context
+
+
+class PrefixedStream:
+    """
+    Wrapper class around a stream adding a prefix to each writen line.
+    """
+    def __init__(self, src_stream, prefix):
+        self.prefix = prefix
+        self.src_stream = src_stream
+        self.buffer = ''
+
+    def write(self, data):
+        self.buffer += data
+        self.flush()
+
+    def flush(self):
+        lines = self.buffer.split('\n')
+
+        for line in lines[:-1]:
+            self.src_stream.write('[{}] {}\n'.format(self.prefix, line))
+
+        self.buffer = lines[-1]
+
+
+class PrefixedContext(context.Context):
+    """
+    Wrapper class around a pyinvoke context adding a prefix to each lines
+    outputed by ctx.run(..).
+    """
+    def __init__(self, ctx, prefix):
+        super().__init__(ctx.config)
+        self.prefix = prefix
+
+    def run(self, *args, **kwargs):
+        return super().run(
+            *args,
+            **kwargs,
+            out_stream=PrefixedStream(sys.stdout, self.prefix),
+            err_stream=PrefixedStream(sys.stderr, self.prefix + ':ERR'),
+        )
+
+def format_stdout(fun):
+    """
+    Wrapper decorator around a task adding its name to each line outputed by
+    ctx.run(..).
+    """
+    @wraps(fun)
+    def upgraded_fun(ctx, *args, **kwargs):
+        ctx = PrefixedContext(ctx, fun.__name__)
+        fun(ctx, *args, **kwargs)
+
+    return upgraded_fun

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -397,8 +397,12 @@ def run_post_sql_scripts(ctx):
 def load_osm(ctx):
     if ctx.osm.url:
         get_osm_data(ctx)
-    load_basemap(ctx)
-    load_poi(ctx)
+
+    concurrent.futures.wait([
+        cc_exec.submit(load_basemap, ctx),
+        cc_exec.submit(load_poi, ctx)
+    ])
+
     run_sql_script(ctx)
 
 

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -41,11 +41,10 @@ class PrefixedStream:
 
         for line in lines[:-1]:
             self.src_stream.write(
-                '\033[0;90m[{}]\033[0;0m {}\n'.format(self.prefix, line)
+                '[{}] {}\n'.format(self.prefix, line)
             )
 
         self.buffer = lines[-1]
-        self.src_stream.flush()
 
 
 class PrefixedContext(context.Context):

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -53,7 +53,7 @@ class PrefixedContext(context.Context):
     outputed by ctx.run(..).
     """
     def __init__(self, ctx, prefix):
-        self.__dict__ = ctx.__dict__.copy()
+        super().__init__(ctx.config)
         self.prefix = prefix
 
     def run(self, *args, **kwargs):

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -158,7 +158,8 @@ def _run_imposm_import(ctx, mapping_filename, tileset_name):
   -deployproduction -overwritecache \
   -optimize \
   -quiet \
-  -diffdir {ctx.generated_files_dir}/diff/{tileset_name} -cachedir {ctx.generated_files_dir}/cache/{tileset_name}'
+  -diffdir {ctx.generated_files_dir}/diff/{tileset_name} -cachedir {ctx.generated_files_dir}/cache/{tileset_name} \
+  -dbschema-import {tileset_name}'
     )
 
 

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -647,7 +647,6 @@ def generate_tiles(ctx):
 
 
 @task
-@format_stdout
 def generate_expired_tiles(ctx, tiles_layer, from_zoom, before_zoom, expired_tiles):
     logging.info("generating expired tiles from %s", expired_tiles)
     create_tiles_jobs(

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -110,7 +110,7 @@ def _get_osmupdate_options(ctx, box=None):
 
 
 @task
-def get_osm_data(ctx, update_pbf=True):
+def get_osm_data(ctx):
     """
     download the osm file and store it in the input_data directory
     """
@@ -126,7 +126,7 @@ def get_osm_data(ctx, update_pbf=True):
     ctx.osm.file = new_osm_file
     download_file(ctx, new_osm_file, ctx.osm.url, max_age=timedelta(days=3))
 
-    if update_pbf:
+    if ctx.osm.update_pbf:
         pbf_reader = osmium.io.Reader(new_osm_file)
         pbf_bbox = pbf_reader.header().box()
         if pbf_bbox is not None and pbf_bbox.size() > 60000:

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -388,10 +388,8 @@ def run_post_sql_scripts(ctx):
     this file has been generated using https://github.com/QwantResearch/openmaptiles
     """
     logging.info("running postsql scripts")
-    concurrent.futures.wait([
-        cc_exec.submit(_run_sql_script, ctx, "generated_base.sql"),
-        cc_exec.submit(_run_sql_script, ctx, "generated_poi.sql"),
-    ])
+    _run_sql_script(ctx, "generated_base.sql")
+    _run_sql_script(ctx, "generated_poi.sql")
 
 
 @task
@@ -399,10 +397,8 @@ def run_post_sql_scripts(ctx):
 def load_osm(ctx):
     if ctx.osm.url:
         get_osm_data(ctx)
-
     load_basemap(ctx)
     load_poi(ctx)
-
     run_sql_script(ctx)
 
 


### PR DESCRIPTION
Speed up import by parallelizing some unrelated tasks.

Results of consecutive runs for imports of Luxembourg on my laptop:

|      branch     | with stats | duration (mm:ss) |
|:---------------:|:----------:|:----------------:|
|      master     |     no     |       14:21      |
| parallel-import |     no     |       10:32      |
|      master     |     yes    |       53:50      |
| parallel-import |     yes    |       37:30      |
| parallel-import + patched openmaptiles |     no    |       6:06      |

Note that the import of borders could internally be parallelized through a PR to openmaptiles: https://gist.github.com/remi-dupre/a963359722ecb7360885cbc390386be7.