### PR TITLE
exec.py: no redirect of stdout

### DIFF
--- a/exec.py
+++ b/exec.py
@@ -21,19 +21,9 @@ COMMANDS = [
 def exec_command(command, options):
     if options.get('debug') is True:
         print('==> {}'.format(' '.join(command)))
-    p = subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT)
-    while True:
-        output = p.stdout.read1(100)
-        if len(output) == 0:
-            rc = p.poll()
-            if rc is not None:
-                return rc
-        if len(output) > 0:
-            sys.stdout.buffer.write(output)
-            sys.stdout.buffer.flush()
+    p = subprocess.Popen(command)
+    p.wait()
+    return p.poll()
 
 
 def get_submodules():


### PR DESCRIPTION
Manually managing the buffer can lead to overflows, especially when dealing with parallelized code. It seems that that Popen's default behavior is to redirect outputs in streaming, thus this piece of code can be removed without any loss.

The bug can be reproduced by calling the following kind of task, this will be likely to raise an uncatched BlockingIOError at [this line](https://github.com/QwantResearch/kartotherian_docker/blob/20a172edd1359748447815b4e26262f3e708f065/exec.py#L35).

```python
cc_exec = concurrent.futures.ThreadPoolExecutor()

@task
def testing(ctx):
    concurrent.futures.wait([
        cc_exec.submit(test_print, ctx, '1', 10**4),
        cc_exec.submit(test_print, ctx, '2', 10**4),
        cc_exec.submit(test_print, ctx, '3', 10**4),
        cc_exec.submit(test_print, ctx, '4', 10**4),
    ])

def test_print(_ctx, ident, count):
    for i in range(count):
        print('[{}, {}] Neque porro quisquam est qui dolorem ipsum quia dolor '
              'sit amet, consectetur, adipisci velit'.format(ident, i))

```