### PR TITLE
Enable wikidata stats import by default and optimizations

### DIFF
--- a/import_data/invoke.yaml
+++ b/import_data/invoke.yaml
@@ -41,7 +41,7 @@ wikidata:
     table: wd_sitelinks
 
   stats:
-    enabled: false
+    enabled: true
     url: https://github.com/QwantResearch/wikimedia-dumps/releases/download/082019-102019/stats.csv.gz
     file: stats.csv.gz
     table: wm_stats

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -286,6 +286,7 @@ def import_wikimedia_stats(ctx):
     """
     import wikimedia stats (for POI ranking through Wikipedia page views)
     """
+    logging.info("importing wikimedia stats...")
     target_file = os.path.join(ctx.data_dir, ctx.wikidata.stats.file)
     download_file(ctx, target_file, ctx.wikidata.stats.url)
 
@@ -302,6 +303,7 @@ def import_wikimedia_stats(ctx):
 
     connection.commit()
     connection.close()
+    logging.info("importing wikimedia stats done.")
 
 
 @task
@@ -309,6 +311,7 @@ def import_wikidata_sitelinks(ctx):
     """
     import Wikipedia pages links for Wikidata items
     """
+    logging.info("importing wikidata links...")
     target_file = os.path.join(ctx.data_dir, ctx.wikidata.sitelinks.file)
     download_file(ctx, target_file, ctx.wikidata.sitelinks.url)
 
@@ -325,6 +328,7 @@ def import_wikidata_sitelinks(ctx):
 
     connection.commit()
     connection.close()
+    logging.info("importing wikidata links done.")
 
 
 @task
@@ -332,6 +336,7 @@ def import_wikidata_labels(ctx):
     """
     import labels from Wikidata (for some translations)
     """
+    logging.info("importing wikidata labels...")
     target_file = os.path.join(ctx.data_dir, ctx.wikidata.labels.file)
     download_file(ctx, target_file, ctx.wikidata.labels.url)
 
@@ -357,6 +362,7 @@ def import_wikidata_labels(ctx):
 
         connection.commit()
         connection.close()
+    logging.info("importing wikidata labels done.")
 
 
 @task

--- a/load_db/Dockerfile
+++ b/load_db/Dockerfile
@@ -13,10 +13,10 @@ RUN apt-get update && \
         postgresql-client \
         jq \
     && rm -rf /var/lib/apt/lists/* \
-# install imposm 0.8.1 (custom release, waiting for https://github.com/omniscale/imposm3/pull/206 to be merged)
-    && wget https://github.com/amatissart/imposm3/releases/download/v0.8.1-qwant-0/imposm-0.8.1-qwant-0-linux-x86-64.tar.gz \
-    && tar xvfz imposm-0.8.1-qwant-0-linux-x86-64.tar.gz \
-    && ln -sf /imposm-0.8.1-qwant-0-linux-x86-64/imposm /usr/local/bin/imposm3 \
+# install imposm 0.9.0 (custom release, waiting for https://github.com/omniscale/imposm3/pull/206 to be merged)
+    && wget https://github.com/amatissart/imposm3/releases/download/v0.9.0-qwant.0/imposm-0.9.0-qwant.0-linux-x86-64.tar.gz \
+    && tar xvfz imposm-0.9.0-qwant.0-linux-x86-64.tar.gz \
+    && ln -sf /imposm-0.9.0-qwant.0-linux-x86-64/imposm /usr/local/bin/imposm3 \
     && wget -O /usr/local/bin/pgfutter https://github.com/lukasmartinelli/pgfutter/releases/download/v1.1/pgfutter_linux_amd64 \
     && chmod +x /usr/local/bin/pgfutter \
     && pip install pipenv==2018.11.26


### PR DESCRIPTION
* Enable wikidata stats import by default
* Upgrade to imposm v0.9 (with db optimizations: https://github.com/omniscale/imposm3/commit/3b6e6b38f4529ac468580040dff25a0b47a037c9)
* Add logging messages