### PR TITLE
Disable pbf update on non-planet files (avoid high memory usage by imposm)

### DIFF
--- a/import_data/invoke.yaml
+++ b/import_data/invoke.yaml
@@ -31,7 +31,7 @@ osm:
   url:
   ## Path of the file
   file:
-  # Fetch and apply updates on .pbf file before importing
+  # Fetch and apply updates on .pbf file before importing (applies only for planet files)
   update_pbf: True
 
 # Toggle import of statistics and metadata from Wikidata

--- a/import_data/tasks/format_stdout.py
+++ b/import_data/tasks/format_stdout.py
@@ -24,6 +24,7 @@ class PrefixedStream:
             self.src_stream.write('[{}] {}\n'.format(self.prefix, line))
 
         self.buffer = lines[-1]
+        self.src_stream.flush()
 
 
 class PrefixedContext(context.Context):


### PR DESCRIPTION
For unclear reasons, applying updates on a geographical pbf extract lead to higher memory requirements for imposm. Possibly because of broken references in the file.

As this feature is only useful for planet files (that are typically downloaded with a several days delay), this PR suggests to apply this pre-import update on these files only.