### PR TITLE
display_poi_weight: compute max and min views with percentiles

### DIFF
--- a/import_data/Pipfile
+++ b/import_data/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 
 [packages]
 invoke = "*"
+jinja2 = "*"
 requests = ">=2.20.0"
 openmaptiles-tools = ">=0.9.2"
 psycopg2 = "*"

--- a/import_data/Pipfile.lock
+++ b/import_data/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "14b92bcfb3d910be861790411a08077a1cf7943a08ef6e3cbed910e07cd5e435"
+            "sha256": "a44612d3358554cef4672fb7bb958e8872c7521b052129b77ea3450fc412836a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -66,6 +66,47 @@
             ],
             "index": "pypi",
             "version": "==0.9.2"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f",
+                "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"
+            ],
+            "index": "pypi",
+            "version": "==2.10.3"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+            ],
+            "version": "==1.1.1"
         },
         "osmium": {
             "hashes": [

--- a/import_data/import-wikidata/wikidata_functions.sql
+++ b/import_data/import-wikidata/wikidata_functions.sql
@@ -1,6 +1,27 @@
+-- Compute a percentile on the set of page view counts for POIs for which a
+-- Wikipedia page was found.
+CREATE OR REPLACE FUNCTION poi_pageviews_percentile(fraction REAL)
+RETURNS INTEGER AS
+$$
+    SELECT PERCENTILE_DISC(fraction) WITHIN GROUP (ORDER BY all_poi.max_views)
+    FROM (
+        SELECT MAX(stats.views) AS max_views
+        FROM (
+                SELECT osm_id, name, tags FROM osm_poi_polygon
+                    UNION ALL
+                SELECT osm_id, name, tags FROM osm_poi_point
+            ) AS poi
+        JOIN wd_sitelinks AS site
+            ON site.id = poi.tags->'wikidata'
+        JOIN wm_stats AS stats
+            ON site.lang = stats.lang AND site.title = stats.title
+        GROUP BY poi.osm_id
+    ) AS all_poi
+$$ LANGUAGE sql IMMUTABLE;
+
 -- Override default `poi_display_weight` function from
 -- https://github.com/QwantResearch/openmaptiles/.
--- 
+--
 -- Primarily, this function relies on the count of page views for the Wikipedia
 -- pages of a POI, if no Wikipedia page is found, this will fallback on the
 -- default implementation.
@@ -16,16 +37,16 @@ RETURNS REAL AS $$
         -- https://github.com/QwantResearch/openmaptiles/blob/master/layers/poi/class.sql
         max_rank  CONSTANT REAL := 1000.;
 
-        -- Upper limit to the number of views of a Wikipedia page, this limit
-        -- should be sufficient for a period of time of about a year.
-        max_views CONSTANT REAL := 1e6;
-
         -- Lower limit to the number of view of a Wikipedia page to consider it
         -- relevant. If a page generates less views than this limit, the output
         -- value will be computed as if this page doesn't exist.
-        min_views CONSTANT REAL := 50.;
+        min_views CONSTANT REAL := poi_pageviews_percentile(0.1);
 
-        views_count real;
+        -- Upper limit to the number of views of a Wikipedia page. Pages with a
+        -- greater number of views will have a weight of 1.
+        max_views CONSTANT REAL := poi_pageviews_percentile(0.999);
+
+        views_count REAL;
     BEGIN
         SELECT INTO views_count
             CASE
@@ -39,8 +60,9 @@ RETURNS REAL AS $$
                     0
             END;
         RETURN CASE
-            WHEN views_count > min_views THEN
-                0.5 * (1 + LOG(LEAST(max_views, views_count)) / LOG(max_views))
+            WHEN views_count > min_views AND max_views - min_views > 1 THEN
+                0.5 + 0.5 * LOG(LEAST(max_views, views_count) - min_views)
+                             / LOG(max_views - min_views)
             WHEN name <> '' THEN
                 0.5 * (
                     1 - poi_class_rank(poi_class(subclass, mapping_key))::real / max_rank

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -69,7 +69,12 @@ def _run_sql_script(ctx, script_name, template_params=None):
                 jinja2.Template(sql_commands).render(**template_params)
             )
 
-        return _execute_sql(ctx, sql_commands, db=ctx.pg.import_database)
+        return _execute_sql(
+            ctx,
+            sql_commands,
+            db=ctx.pg.import_database,
+            additional_options="--set ON_ERROR_STOP='1'"
+        )
 
 def _db_exists(ctx, db_name):
     has_db = _execute_sql(


### PR DESCRIPTION
Ensures that weights will correctly be spread from 0.5 to 1 for POIs with a linked Wikipedia page. Also, this makes `poi_display_weight` less dependent of the period of time considered for metrics.

 - top 0.1% POIs will have a weight of 1 (in île-de-France only it includes Tour Eiffel, Musé du Louvre, Cathédrale Notre-Dame and Château de Versailles)
 - the POIs with the least 10% of page views will have a weight computed by ignoring the Wikipedia page (~ less than 10 views / month on current dataset)

Note that the two percentiles are quite expensive to compute, but will only be computed for the first run of `poi_display_weight`.