### PR TITLE
Reindex osm_poi_polygon geometries to avoid bloat after successive updates

### DIFF
--- a/import_data/invoke.yaml
+++ b/import_data/invoke.yaml
@@ -88,3 +88,4 @@ tiles:
 
 osm_update:
   replication_url: https://planet.osm.org/replication
+  reindex_poi_geometries: True

--- a/import_data/osm_update.sh
+++ b/import_data/osm_update.sh
@@ -15,6 +15,11 @@ LOG_DIR=$OSM_UPDATE_WORKING_DIR/log
 LOG_FILE=$LOG_DIR/${EXEC_TIME}.$(basename $0 .sh).log
 LOG_MAXDAYS=7  # Log files are kept $LOG_MAXDAYS days
 INVOKE_CONFIG_FILE="${INVOKE_CONFIG_FILE:-}"
+INVOKE_OPTION=""
+if [ ! -z "$INVOKE_CONFIG_FILE" ]; then
+    INVOKE_OPTION="-f $INVOKE_CONFIG_FILE"
+fi
+
 
 # imposm
 IMPOSM_CONFIG_DIR="/etc/imposm" # default value, can be set with the --config option
@@ -108,11 +113,6 @@ create_tiles_jobs() {
 
     log "file with tile to regenerate = $EXPIRE_TILES_FILE"
 
-    local INVOKE_OPTION=""
-    if [ ! -z "$INVOKE_CONFIG_FILE" ]; then
-        INVOKE_OPTION="-f $INVOKE_CONFIG_FILE"
-    fi
-
     invoke $INVOKE_OPTION generate-expired-tiles \
         --tiles-layer $TILES_LAYER_NAME \
         --from-zoom $FROM_ZOOM \
@@ -188,6 +188,9 @@ if [ -s ${CHANGE_FILE} ]; then
     # Imposm update for both tiles sources
     run_imposm_update $BASE_IMPOSM_CONFIG_FILENAME
     run_imposm_update $POI_IMPOSM_CONFIG_FILENAME
+
+    # Reindex geometries to avoid index bloat
+    invoke $INVOKE_OPTION reindex-poi-geometries
 
     # Create tiles jobs for both tiles sources
     create_tiles_jobs $BASE_IMPOSM_CONFIG_FILENAME $BASE_TILERATOR_GENERATOR $BASE_TILERATOR_STORAGE

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -813,6 +813,17 @@ def get_import_lock_path(ctx):
 
 
 @task
+def reindex_poi_geometries(ctx):
+    """
+    Successive updates tend to bloat some of the geometry indexes significantly.
+    This task triggers a forced REINDEX after the update has been applied.
+    """
+    if not ctx.osm_update.reindex_poi_geometries:
+        return
+    _execute_sql(ctx, "REINDEX (VERBOSE) INDEX osm_poi_polygon_geom", db=ctx.pg.database)
+
+
+@task
 @format_stdout
 def run_osm_update(ctx):
     update_env = {


### PR DESCRIPTION
Timeout during POI tiles generation have been observed after several weeks of successive updates.   

A regular REINDEX on `osm_poi_polygon` geometries (which are potentially updated after each run of osm_update to find a centroid for each new polygons) should solve this issue.