### PR TITLE
Reduce Cassandra memory usage for local runs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
      - POSTGRES_PASSWORD=gis
 
   cassandra:
-    image: cassandra:latest
+    image: cassandra:3
     volumes:
      - "cassandra_data:/var/lib/cassandra"
 

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -1,6 +1,11 @@
 version: '3'
 
 services:
+  cassandra:
+    environment:
+      - "MAX_HEAP_SIZE=1G"
+      - "HEAP_NEWSIZE=250M"
+
 
   tilerator:
     ports:


### PR DESCRIPTION
Cassandra sets the heap size to 1/4 ram in most situations:
https://docs.datastax.com/en/cassandra-oss/3.x/cassandra/operations/opsTuneJVM.html#Determiningtheheapsize

For testing purposes where all services run on the same machine this value is too high for no benefit.
This PR sets lower values in `local-compose.yml` used on local environments.