### PR TITLE
Style cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
+language: python
+
 services:
   - docker
+
+python:
+  - "3.6"
 
 env:
   global:
     - DOCKER_IMAGE_PREFIX=qwantresearch/kartotherian
   matrix:
+    - SERVICE=linter
     - SERVICE=load_db
     - SERVICE=tilerator
     - SERVICE=kartotherian
@@ -12,12 +18,18 @@ env:
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
-    echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+        echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USERNAME" --password-stdin;
     fi
 
-script:
-  - export DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}_$SERVICE"
-  - docker build --label "org.label-schema.vcs-ref=$TRAVIS_COMMIT" -t $DOCKER_IMAGE -f ./$SERVICE/Dockerfile .
-  - if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
-    docker push $DOCKER_IMAGE;
+script: >
+    if [ "$SERVICE" == "linter" ]; then
+        pip install --pre black
+        black --diff --check .
+    else
+        export DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}_$SERVICE"
+        docker build --label "org.label-schema.vcs-ref=$TRAVIS_COMMIT" -t $DOCKER_IMAGE -f ./$SERVICE/Dockerfile .
+
+        if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+            docker push $DOCKER_IMAGE;
+        fi
     fi

--- a/exec.py
+++ b/exec.py
@@ -20,7 +20,7 @@ COMMANDS = [
 
 def exec_command(command, options):
     if options.get("debug") is True:
-        print("==> {}".format(" ".join(command)))
+        print("==>", " ".join(command))
     p = subprocess.Popen(command)
     p.wait()
     return p.poll()
@@ -94,9 +94,9 @@ def run_load_db(options):
         return ret
     print("> running load-db command")
     if options["osm-file"].startswith("https://") or options["osm-file"].startswith("http://"):
-        flag = "INVOKE_OSM_URL={}".format(options["osm-file"])
+        flag = f"INVOKE_OSM_URL={options['osm-file']}"
     else:
-        flag = "INVOKE_OSM_FILE={}".format(options["osm-file"])
+        flag = f"INVOKE_OSM_FILE={options['osm-file']}"
     command = [
         "docker-compose",
         "-p",
@@ -110,7 +110,7 @@ def run_load_db(options):
         "-e",
         flag,
         "-e",
-        "INVOKE_TILES_COORDS={}".format(options["tiles-coords"]),
+        f"INVOKE_TILES_COORDS={options['tiles-coords']}",
         "load_db",
     ]
     return exec_command(command, options)
@@ -266,7 +266,7 @@ def parse_args(args):
             enabled_options[args[i - 1][2:]] = args[i]
         elif args[i] == "--tiles-coords":
             if i + 1 >= len(args):
-                print("`{}` option expects an argument!".format(args[i]))
+                print(f"`{args[i]}` option expects an argument!")
                 sys.exit(1)
             i += 1
             try:
@@ -295,9 +295,7 @@ def parse_args(args):
             sys.exit(0)
         else:
             print(
-                "Unknown option `{}`, run with with `-h` or `--help` to see the list of commands".format(
-                    args[i]
-                )
+                f"Unknown option `{args[i]}`, run with with `-h` or `--help` to see the list of commands"
             )
             sys.exit(1)
         i += 1
@@ -309,10 +307,10 @@ def main():
     options = parse_args(sys.argv[1:])
     for key in options:
         if key in COMMANDS and options[key] is True:
-            func_name = "run_{}".format(key.replace("-", "_"))
+            func_name = "run_" + key.replace("-", "_")
             ret = definitions[func_name](options)
             if ret != 0:
-                print("{} command failed".format(key))
+                print(f"{key} command failed")
                 sys.exit(ret)
 
 

--- a/exec.py
+++ b/exec.py
@@ -1,33 +1,46 @@
 #!/usr/bin/env python3
 
+import argparse
 import subprocess
+import re
 import sys
 import os
-import json
+from itertools import chain
+
+# Commands that will require a load db
+LOAD_DB_COMMANDS = ["load-db", "load-db-france", "tileview"]
+
+# Commands that will require a build
+BUILD_COMMANDS = ["build", "kartotherian"] + LOAD_DB_COMMANDS
 
 
-COMMANDS = [
-    "build",
-    "load-db",
-    "load-db-france",
-    "update-tiles",
-    "clean",
-    "logs",
-    "kartotherian",
-    "tileview",
-]
+def exec_command(command, debug=False):
+    if debug:
+        print("===>", " ".join(command), file=sys.stderr)
 
-
-def exec_command(command, options):
-    if options.get("debug") is True:
-        print("==>", " ".join(command))
     p = subprocess.Popen(command)
     p.wait()
     return p.poll()
 
 
+def docker_exec(docker_cmd, namespace, debug=False):
+    init_submodule_if_not(debug)
+    return exec_command(
+        ["docker-compose", "-p", namespace, "-f", "docker-compose.yml", "-f", "local-compose.yml"]
+        + docker_cmd,
+        debug,
+    )
+
+
+def docker_run(params, namespace, debug=False, env={}):
+    env_params = list(chain.from_iterable(["-e", f"{key}={val}"] for key, val in env.items()))
+    command = ["run", "--rm"] + env_params + params
+    return docker_exec(command, namespace, debug)
+
+
 def get_submodules():
     dirs = []
+
     try:
         with open(".gitmodules", "r") as f:
             for line in f:
@@ -37,281 +50,115 @@ def get_submodules():
                 dirs.append(line.split("path = ")[1])
     except Exception as err:
         print(f"error happened when trying to get submodules: {err}")
+
     return dirs
 
 
-def init_submodule_if_not(options):
+def init_submodule_if_not(debug=False):
     submodules = get_submodules()
+
     for sub in submodules:
         if len(os.listdir(sub)) == 0:
-            if exec_command(["git", "submodule", "update", "--init", sub], options) != 0:
+            if exec_command(["git", "submodule", "update", "--init", sub], debug) != 0:
                 print(f'Failed to update submodule "{sub}"')
 
 
-def run_kartotherian(options):
-    init_submodule_if_not(options)
-    print("> running kartotherian command")
-    return exec_command(
-        [
-            "docker-compose",
-            "-p",
-            options["namespace"],
-            "-f",
-            "docker-compose.yml",
-            "-f",
-            "local-compose.yml",
-            "up",
-            "--build",
-            "-d",
-        ],
-        options,
+def build_argparser():
+    parser = argparse.ArgumentParser(
+        prog="kartotherian_docker",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+            Generally, it runs in this order: build > load-db(-france) > kartotherian (> logs)
+            To update, it runs in this order: build > load-db(-france) > update-tiles (> logs)
+            To debug, it runs in this order:  build > load-db(-france) > tileview (> logs)
+        """,
     )
 
-
-def run_build(options):
-    init_submodule_if_not(options)
-    print("> running build command")
-    return exec_command(
-        [
-            "docker-compose",
-            "-p",
-            options["namespace"],
-            "-f",
-            "docker-compose.yml",
-            "-f",
-            "local-compose.yml",
-            "up",
-            "--build",
-            "-d",
-        ],
-        options,
+    parser.add_argument("--debug", action="store_true", help="show more information on the run")
+    parser.add_argument(
+        "--namespace",
+        default="kartotherian_docker",
+        help="set the --project option of docker-compose, allowing to change name prefix",
     )
 
-
-def run_load_db(options):
-    ret = run_build(options)
-    if ret != 0:
-        return ret
-    print("> running load-db command")
-    if options["osm-file"].startswith("https://") or options["osm-file"].startswith("http://"):
-        flag = f"INVOKE_OSM_URL={options['osm-file']}"
-    else:
-        flag = f"INVOKE_OSM_FILE={options['osm-file']}"
-    command = [
-        "docker-compose",
-        "-p",
-        options["namespace"],
-        "-f",
-        "docker-compose.yml",
-        "-f",
-        "local-compose.yml",
-        "run",
-        "--rm",
-        "-e",
-        flag,
-        "-e",
-        f"INVOKE_TILES_COORDS={options['tiles-coords']}",
-        "load_db",
-    ]
-    return exec_command(command, options)
-
-
-def run_load_db_france(options):
-    options["osm-file"] = "https://download.geofabrik.de/europe/france-latest.osm.pbf"
-    # got tiles from http://tools.geofabrik.de/calc/?grid=1
-    options["tiles-coords"] = "[[15, 10, 5], [16, 10, 5], [15, 11, 5], [16, 11, 5]]"
-    run_load_db(options)
-
-
-def run_update_tiles(options):
-    # needs to be run after load-db, adding a check for it would be nice.
-    print("> running update-tiles command")
-    return exec_command(
-        [
-            "docker-compose",
-            "-p",
-            options["namespace"],
-            "-f",
-            "docker-compose.yml",
-            "-f",
-            "local-compose.yml",
-            "run",
-            "--rm",
-            "load_db",
-            "run-osm-update",
-        ],
-        options,
-    )
-
-
-def run_clean(options):
-    print("> running clean command")
-    return exec_command(
-        [
-            "docker-compose",
-            "-p",
-            options["namespace"],
-            "-f",
-            "docker-compose.yml",
-            "-f",
-            "local-compose.yml",
-            "down",
-            "-v",
-        ],
-        options,
-    )
-
-
-def run_logs(options):
-    print("> running logs command")
-    command = [
-        "docker-compose",
-        "-p",
-        options["namespace"],
-        "-f",
-        "docker-compose.yml",
-        "-f",
-        "local-compose.yml",
-        "logs",
-    ]
-    for f in options["filter"]:
-        command.append(f)
-    return exec_command(command, options)
-
-
-def run_tileview(options):
-    print("> running tileview command")
-    ret = run_load_db(options)
-    if ret != 0:
-        return ret
-    return exec_command(
-        [
-            "docker-compose",
-            "-p",
-            options["namespace"],
-            "-f",
-            "docker-compose.yml",
-            "-f",
-            "local-compose.yml",
-            "up",
-            "-d",
-            "tileview",
-        ],
-        options,
-    )
-
-
-def run_help():
-    print("== kartotherian_docker options ==")
-    print("")
-    print("Generally, it runs in this order: build > load-db(-france) > kartotherian (> logs)")
-    print("To update, it runs in this order: build > load-db(-france) > update-tiles (> logs)")
-    print("To debug, it runs in this order:  build > load-db(-france) > tileview (> logs)")
-    print("")
-    print("  build         : build basics")
-    print("  kartotherian  : launch (and build) kartotherian")
-    print("  load-db       : load data from the given `--osm-file` (luxembourg by default)")
-    print("  load-db-france: load data (tiles too) for the french country")
-    print("  tileview      : run a map server which allows to get detailed tiles information")
-    print("  update-tiles  : update the tiles data")
-    print("  clean         : stop and remove running docker instances")
-    print("  logs          : show docker logs (can be filtered with `--filter` option)")
-    print("  --debug       : show more information on the run")
-    print("  --filter      : container to show on `logs` command")
-    print(
-        "  --osm-file    : file or URL to be used for pbf file in `load-db`, luxembourg by default"
-    )
-    print(
-        "  --tiles-coords: needs to be an array of arrays (each of len 3). Defaults to [[66, 43, 7]]."
-    )
-    print("                  You can find coords by using http://tools.geofabrik.de/calc/?grid=1")
-    print("                  Used in load-db(-france) command.")
-    print(
-        "  --namespace   : set the --project option of docker-compose, allowing to change name prefix "
-    )
-    print("                  of all used docker images")
-    print("  -h | --help   : show this help")
-    sys.exit(0)
-
-
-def parse_args(args):
-    if len(args) == 0:
-        run_help()
-        sys.exit(0)
-    available_options = ["--no-dependency-run", "--debug"]
-    available_options.extend(COMMANDS)
-    enabled_options = {
-        "osm-file": "https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf",
-        "filter": [],
-        "tiles-coords": "[[66, 43, 7]]",
-        "namespace": "kartotherian_docker",
+    subparsers = parser.add_subparsers(dest="command")
+    subcommands = {
+        cmd: subparsers.add_parser(cmd, help=cmd_help)
+        for cmd, cmd_help in [
+            ("build", "build basics"),
+            ("kartotherian", "launch (and build) kartotherian"),
+            ("load-db", "load data from the given `--osm-file` (luxembourg by default)"),
+            ("load-db-france", "load data (tiles too) for the french country"),
+            ("tileview", "run a map server which allows to get detailed tiles information"),
+            ("update-tiles", "update the tiles data"),
+            ("clean", "stop and remove running docker instances"),
+            ("logs", "show docker logs (can be filtered with `--filter` option)"),
+        ]
     }
-    i = 0
-    while i < len(args):
-        if args[i] in available_options:
-            if args[i].startswith("--"):
-                args[i] = args[i][2:]
-            enabled_options[args[i]] = True
-        elif args[i] == "--filter":
-            if i + 1 >= len(args):
-                print("`--filter` option expects an argument!")
-                sys.exit(1)
-            i += 1
-            enabled_options[args[i - 1][2:]].append(args[i])
-        elif args[i] == "--osm-file":
-            if i + 1 >= len(args):
-                print("`--osm-file` option expects an argument!")
-                sys.exit(1)
-            i += 1
-            enabled_options[args[i - 1][2:]] = args[i]
-        elif args[i] == "--tiles-coords":
-            if i + 1 >= len(args):
-                print(f"`{args[i]}` option expects an argument!")
-                sys.exit(1)
-            i += 1
-            try:
-                d = json.loads(args[i])
-                if not isinstance(d, list):
-                    print(f"`{args[i - 1]}` option expects an array of [longitude, latitude, zoom]")
-                    sys.exit(1)
-                for x in d:
-                    if not isinstance(x, list) or len(x) != 3:
-                        print(
-                            f"`{args[i - 1]}` option expects an array of [longitude, latitude, zoom]"
-                        )
-                        sys.exit(1)
-            except Exception as e:
-                print(f"`{args[i - 1]}` option expects an array of [longitude, latitude, zoom]")
-                sys.exit(1)
-            enabled_options[args[i - 1][2:]] = args[i]
-        elif args[i] == "--namespace":
-            if i + 1 >= len(args):
-                print("`--namespace` option expects an argument!")
-                sys.exit(1)
-            i += 1
-            enabled_options[args[i - 1][2:]] = args[i]
-        elif args[i] == "-h" or args[i] == "--help":
-            run_help()
-            sys.exit(0)
-        else:
-            print(
-                f"Unknown option `{args[i]}`, run with with `-h` or `--help` to see the list of commands"
-            )
-            sys.exit(1)
-        i += 1
-    return enabled_options
+
+    # DB loading specific parameters
+
+    for cmd in LOAD_DB_COMMANDS:
+        def_file = "europe/luxembourg" if cmd != "load-db-france" else "europe/france"
+        def_coords = (
+            "[[66, 43, 7]]"
+            if cmd != "load-db-france"
+            else "[[15, 10, 5], [16, 10, 5], [15, 11, 5], [16, 11, 5]]"
+        )
+
+        subcommands[cmd].add_argument(
+            "--osm-file",
+            default=f"https://download.geofabrik.de/{def_file}-latest.osm.pbf",
+            help="file or URL to be used for pbf file, luxembourg by default",
+        )
+
+        subcommands[cmd].add_argument(
+            "--tiles-coords",
+            default=def_coords,
+            help="""
+                Needs to be an array of arrays (each of len 3).
+                You can find coords by using http://tools.geofabrik.de/calc/?grid=1
+            """,
+        )
+
+    # `logs` specific parameters
+
+    subcommands["logs"].add_argument(
+        "--filter", action="append", default=[], help="container to show"
+    )
+
+    return parser
 
 
 def main():
-    definitions = globals()
-    options = parse_args(sys.argv[1:])
-    for key in options:
-        if key in COMMANDS and options[key] is True:
-            func_name = "run_" + key.replace("-", "_")
-            ret = definitions[func_name](options)
-            if ret != 0:
-                print(f"{key} command failed")
-                sys.exit(ret)
+    parser = build_argparser()
+    args = parser.parse_args()
+
+    if args.command in BUILD_COMMANDS:
+        docker_exec(["up", "--build", "-d"], args.namespace, args.debug)
+
+    if args.command in LOAD_DB_COMMANDS:
+        is_url = re.match("https?://.*", args.osm_file)
+        file_key = "INVOKE_OSM_URL" if is_url else "INVOKE_OSM_FILE"
+
+        docker_run(
+            ["load_db"],
+            args.namespace,
+            args.debug,
+            env={file_key: args.osm_file, "INVOKE_TILES_COORDS": args.tiles_coords},
+        )
+
+    if args.command == "tileview":
+        docker_exec(["up", "-d", "tileview"], args.namespace, args.debug)
+
+    if args.command == "update-tiles":
+        docker_run(["load_db", "run-osm-update"], args.namespace, args.debug)
+
+    if args.command == "clean":
+        docker_exec(["down", "-v"], args.namespace, args.debug)
+
+    if args.command == "logs":
+        docker_exec(["logs"], args.namespace, args.debug)
 
 
 if __name__ == "__main__":

--- a/exec.py
+++ b/exec.py
@@ -7,20 +7,20 @@ import json
 
 
 COMMANDS = [
-    'build',
-    'load-db',
-    'load-db-france',
-    'update-tiles',
-    'clean',
-    'logs',
-    'kartotherian',
-    'tileview',
+    "build",
+    "load-db",
+    "load-db-france",
+    "update-tiles",
+    "clean",
+    "logs",
+    "kartotherian",
+    "tileview",
 ]
 
 
 def exec_command(command, options):
-    if options.get('debug') is True:
-        print('==> {}'.format(' '.join(command)))
+    if options.get("debug") is True:
+        print("==> {}".format(" ".join(command)))
     p = subprocess.Popen(command)
     p.wait()
     return p.poll()
@@ -29,14 +29,14 @@ def exec_command(command, options):
 def get_submodules():
     dirs = []
     try:
-        with open('.gitmodules', 'r') as f:
+        with open(".gitmodules", "r") as f:
             for line in f:
                 line = line.strip()
-                if not line.startswith('path = '):
+                if not line.startswith("path = "):
                     continue
-                dirs.append(line.split('path = ')[1])
+                dirs.append(line.split("path = ")[1])
     except Exception as err:
-        print(f'error happened when trying to get submodules: {err}')
+        print(f"error happened when trying to get submodules: {err}")
     return dirs
 
 
@@ -44,146 +44,193 @@ def init_submodule_if_not(options):
     submodules = get_submodules()
     for sub in submodules:
         if len(os.listdir(sub)) == 0:
-            if exec_command(['git', 'submodule', 'update', '--init', sub], options) != 0:
+            if exec_command(["git", "submodule", "update", "--init", sub], options) != 0:
                 print(f'Failed to update submodule "{sub}"')
 
 
 def run_kartotherian(options):
     init_submodule_if_not(options)
-    print('> running kartotherian command')
-    return exec_command([
-        'docker-compose',
-        '-p', options['namespace'],
-        '-f', 'docker-compose.yml',
-        '-f', 'local-compose.yml',
-        'up',
-        '--build',
-        '-d',
-    ], options)
+    print("> running kartotherian command")
+    return exec_command(
+        [
+            "docker-compose",
+            "-p",
+            options["namespace"],
+            "-f",
+            "docker-compose.yml",
+            "-f",
+            "local-compose.yml",
+            "up",
+            "--build",
+            "-d",
+        ],
+        options,
+    )
 
 
 def run_build(options):
     init_submodule_if_not(options)
-    print('> running build command')
-    return exec_command([
-        'docker-compose',
-        '-p', options['namespace'],
-        '-f', 'docker-compose.yml',
-        '-f', 'local-compose.yml',
-        'up',
-        '--build',
-        '-d',
-    ], options)
+    print("> running build command")
+    return exec_command(
+        [
+            "docker-compose",
+            "-p",
+            options["namespace"],
+            "-f",
+            "docker-compose.yml",
+            "-f",
+            "local-compose.yml",
+            "up",
+            "--build",
+            "-d",
+        ],
+        options,
+    )
 
 
 def run_load_db(options):
     ret = run_build(options)
     if ret != 0:
         return ret
-    print('> running load-db command')
-    if options['osm-file'].startswith('https://') or options['osm-file'].startswith('http://'):
-        flag = 'INVOKE_OSM_URL={}'.format(options['osm-file'])
+    print("> running load-db command")
+    if options["osm-file"].startswith("https://") or options["osm-file"].startswith("http://"):
+        flag = "INVOKE_OSM_URL={}".format(options["osm-file"])
     else:
-        flag = 'INVOKE_OSM_FILE={}'.format(options['osm-file'])
+        flag = "INVOKE_OSM_FILE={}".format(options["osm-file"])
     command = [
-        'docker-compose',
-        '-p', options['namespace'],
-        '-f', 'docker-compose.yml',
-        '-f', 'local-compose.yml',
-        'run', '--rm',
-        '-e', flag,
-        '-e', 'INVOKE_TILES_COORDS={}'.format(options['tiles-coords']),
-        'load_db',
+        "docker-compose",
+        "-p",
+        options["namespace"],
+        "-f",
+        "docker-compose.yml",
+        "-f",
+        "local-compose.yml",
+        "run",
+        "--rm",
+        "-e",
+        flag,
+        "-e",
+        "INVOKE_TILES_COORDS={}".format(options["tiles-coords"]),
+        "load_db",
     ]
     return exec_command(command, options)
 
 
 def run_load_db_france(options):
-    options['osm-file'] = 'https://download.geofabrik.de/europe/france-latest.osm.pbf'
+    options["osm-file"] = "https://download.geofabrik.de/europe/france-latest.osm.pbf"
     # got tiles from http://tools.geofabrik.de/calc/?grid=1
-    options['tiles-coords'] = '[[15, 10, 5], [16, 10, 5], [15, 11, 5], [16, 11, 5]]'
+    options["tiles-coords"] = "[[15, 10, 5], [16, 10, 5], [15, 11, 5], [16, 11, 5]]"
     run_load_db(options)
 
 
 def run_update_tiles(options):
     # needs to be run after load-db, adding a check for it would be nice.
-    print('> running update-tiles command')
-    return exec_command([
-        'docker-compose',
-        '-p', options['namespace'],
-        '-f', 'docker-compose.yml',
-        '-f', 'local-compose.yml',
-        'run', '--rm',
-        'load_db',
-        'run-osm-update',
-    ], options)
+    print("> running update-tiles command")
+    return exec_command(
+        [
+            "docker-compose",
+            "-p",
+            options["namespace"],
+            "-f",
+            "docker-compose.yml",
+            "-f",
+            "local-compose.yml",
+            "run",
+            "--rm",
+            "load_db",
+            "run-osm-update",
+        ],
+        options,
+    )
 
 
 def run_clean(options):
-    print('> running clean command')
-    return exec_command([
-        'docker-compose',
-        '-p', options['namespace'],
-        '-f', 'docker-compose.yml',
-        '-f', 'local-compose.yml',
-        'down',
-        '-v',
-    ], options)
+    print("> running clean command")
+    return exec_command(
+        [
+            "docker-compose",
+            "-p",
+            options["namespace"],
+            "-f",
+            "docker-compose.yml",
+            "-f",
+            "local-compose.yml",
+            "down",
+            "-v",
+        ],
+        options,
+    )
 
 
 def run_logs(options):
-    print('> running logs command')
+    print("> running logs command")
     command = [
-        'docker-compose',
-        '-p', options['namespace'],
-        '-f', 'docker-compose.yml',
-        '-f', 'local-compose.yml',
-        'logs',
+        "docker-compose",
+        "-p",
+        options["namespace"],
+        "-f",
+        "docker-compose.yml",
+        "-f",
+        "local-compose.yml",
+        "logs",
     ]
-    for f in options['filter']:
+    for f in options["filter"]:
         command.append(f)
     return exec_command(command, options)
 
 
 def run_tileview(options):
-    print('> running tileview command')
+    print("> running tileview command")
     ret = run_load_db(options)
     if ret != 0:
         return ret
-    return exec_command([
-        'docker-compose',
-        '-p', options['namespace'],
-        '-f', 'docker-compose.yml',
-        '-f', 'local-compose.yml',
-        'up',
-        '-d', 'tileview',
-    ], options)
+    return exec_command(
+        [
+            "docker-compose",
+            "-p",
+            options["namespace"],
+            "-f",
+            "docker-compose.yml",
+            "-f",
+            "local-compose.yml",
+            "up",
+            "-d",
+            "tileview",
+        ],
+        options,
+    )
 
 
 def run_help():
-    print('== kartotherian_docker options ==')
-    print('')
-    print('Generally, it runs in this order: build > load-db(-france) > kartotherian (> logs)')
-    print('To update, it runs in this order: build > load-db(-france) > update-tiles (> logs)')
-    print('To debug, it runs in this order:  build > load-db(-france) > tileview (> logs)')
-    print('')
-    print('  build         : build basics')
-    print('  kartotherian  : launch (and build) kartotherian')
-    print('  load-db       : load data from the given `--osm-file` (luxembourg by default)')
-    print('  load-db-france: load data (tiles too) for the french country')
-    print('  tileview      : run a map server which allows to get detailed tiles information')
-    print('  update-tiles  : update the tiles data')
-    print('  clean         : stop and remove running docker instances')
-    print('  logs          : show docker logs (can be filtered with `--filter` option)')
-    print('  --debug       : show more information on the run')
-    print('  --filter      : container to show on `logs` command')
-    print('  --osm-file    : file or URL to be used for pbf file in `load-db`, luxembourg by default')
-    print('  --tiles-coords: needs to be an array of arrays (each of len 3). Defaults to [[66, 43, 7]].')
-    print('                  You can find coords by using http://tools.geofabrik.de/calc/?grid=1')
-    print('                  Used in load-db(-france) command.')
-    print('  --namespace   : set the --project option of docker-compose, allowing to change name prefix ')
-    print('                  of all used docker images')
-    print('  -h | --help   : show this help')
+    print("== kartotherian_docker options ==")
+    print("")
+    print("Generally, it runs in this order: build > load-db(-france) > kartotherian (> logs)")
+    print("To update, it runs in this order: build > load-db(-france) > update-tiles (> logs)")
+    print("To debug, it runs in this order:  build > load-db(-france) > tileview (> logs)")
+    print("")
+    print("  build         : build basics")
+    print("  kartotherian  : launch (and build) kartotherian")
+    print("  load-db       : load data from the given `--osm-file` (luxembourg by default)")
+    print("  load-db-france: load data (tiles too) for the french country")
+    print("  tileview      : run a map server which allows to get detailed tiles information")
+    print("  update-tiles  : update the tiles data")
+    print("  clean         : stop and remove running docker instances")
+    print("  logs          : show docker logs (can be filtered with `--filter` option)")
+    print("  --debug       : show more information on the run")
+    print("  --filter      : container to show on `logs` command")
+    print(
+        "  --osm-file    : file or URL to be used for pbf file in `load-db`, luxembourg by default"
+    )
+    print(
+        "  --tiles-coords: needs to be an array of arrays (each of len 3). Defaults to [[66, 43, 7]]."
+    )
+    print("                  You can find coords by using http://tools.geofabrik.de/calc/?grid=1")
+    print("                  Used in load-db(-france) command.")
+    print(
+        "  --namespace   : set the --project option of docker-compose, allowing to change name prefix "
+    )
+    print("                  of all used docker images")
+    print("  -h | --help   : show this help")
     sys.exit(0)
 
 
@@ -191,62 +238,67 @@ def parse_args(args):
     if len(args) == 0:
         run_help()
         sys.exit(0)
-    available_options = ['--no-dependency-run', '--debug']
+    available_options = ["--no-dependency-run", "--debug"]
     available_options.extend(COMMANDS)
     enabled_options = {
-        'osm-file': 'https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf',
-        'filter': [],
-        'tiles-coords': '[[66, 43, 7]]',
-        'namespace': 'kartotherian_docker',
+        "osm-file": "https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf",
+        "filter": [],
+        "tiles-coords": "[[66, 43, 7]]",
+        "namespace": "kartotherian_docker",
     }
     i = 0
     while i < len(args):
         if args[i] in available_options:
-            if args[i].startswith('--'):
+            if args[i].startswith("--"):
                 args[i] = args[i][2:]
             enabled_options[args[i]] = True
-        elif args[i] == '--filter':
+        elif args[i] == "--filter":
             if i + 1 >= len(args):
-                print('`--filter` option expects an argument!')
+                print("`--filter` option expects an argument!")
                 sys.exit(1)
             i += 1
             enabled_options[args[i - 1][2:]].append(args[i])
-        elif args[i] == '--osm-file':
+        elif args[i] == "--osm-file":
             if i + 1 >= len(args):
-                print('`--osm-file` option expects an argument!')
+                print("`--osm-file` option expects an argument!")
                 sys.exit(1)
             i += 1
             enabled_options[args[i - 1][2:]] = args[i]
-        elif args[i] == '--tiles-coords':
+        elif args[i] == "--tiles-coords":
             if i + 1 >= len(args):
-                print('`{}` option expects an argument!'.format(args[i]))
+                print("`{}` option expects an argument!".format(args[i]))
                 sys.exit(1)
             i += 1
             try:
                 d = json.loads(args[i])
                 if not isinstance(d, list):
-                    print(f'`{args[i - 1]}` option expects an array of [longitude, latitude, zoom]')
+                    print(f"`{args[i - 1]}` option expects an array of [longitude, latitude, zoom]")
                     sys.exit(1)
                 for x in d:
                     if not isinstance(x, list) or len(x) != 3:
-                        print(f'`{args[i - 1]}` option expects an array of [longitude, latitude, zoom]')
+                        print(
+                            f"`{args[i - 1]}` option expects an array of [longitude, latitude, zoom]"
+                        )
                         sys.exit(1)
             except Exception as e:
-                print(f'`{args[i - 1]}` option expects an array of [longitude, latitude, zoom]')
+                print(f"`{args[i - 1]}` option expects an array of [longitude, latitude, zoom]")
                 sys.exit(1)
             enabled_options[args[i - 1][2:]] = args[i]
-        elif args[i] == '--namespace':
+        elif args[i] == "--namespace":
             if i + 1 >= len(args):
-                print('`--namespace` option expects an argument!')
+                print("`--namespace` option expects an argument!")
                 sys.exit(1)
             i += 1
             enabled_options[args[i - 1][2:]] = args[i]
-        elif args[i] == '-h' or args[i] == '--help':
+        elif args[i] == "-h" or args[i] == "--help":
             run_help()
             sys.exit(0)
         else:
-            print('Unknown option `{}`, run with with `-h` or `--help` to see the list of commands'
-                .format(args[i]))
+            print(
+                "Unknown option `{}`, run with with `-h` or `--help` to see the list of commands".format(
+                    args[i]
+                )
+            )
             sys.exit(1)
         i += 1
     return enabled_options
@@ -257,12 +309,12 @@ def main():
     options = parse_args(sys.argv[1:])
     for key in options:
         if key in COMMANDS and options[key] is True:
-            func_name = 'run_{}'.format(key.replace('-', '_'))
+            func_name = "run_{}".format(key.replace("-", "_"))
             ret = definitions[func_name](options)
             if ret != 0:
-                print('{} command failed'.format(key))
+                print("{} command failed".format(key))
                 sys.exit(ret)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/import_data/tasks/download.py
+++ b/import_data/tasks/download.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
+
 def needs_to_download(ctx, file, max_age=None):
     """
     Check if "file" should be downloaded
@@ -21,9 +22,7 @@ def needs_to_download(ctx, file, max_age=None):
         if datetime.utcnow() - existing_file_dt > max_age:
             return True
 
-    logger.warning(
-        f"file {file} already exists, we don't need to download it again"
-    )
+    logger.warning(f"file {file} already exists, we don't need to download it again")
     return False
 
 

--- a/import_data/tasks/format_stdout.py
+++ b/import_data/tasks/format_stdout.py
@@ -8,20 +8,21 @@ class PrefixedStream:
     """
     Wrapper class around a stream adding a prefix to each writen line.
     """
+
     def __init__(self, src_stream, prefix):
         self.prefix = prefix
         self.src_stream = src_stream
-        self.buffer = ''
+        self.buffer = ""
 
     def write(self, data):
         self.buffer += data
         self.flush()
 
     def flush(self):
-        lines = self.buffer.split('\n')
+        lines = self.buffer.split("\n")
 
         for line in lines[:-1]:
-            self.src_stream.write('[{}] {}\n'.format(self.prefix, line))
+            self.src_stream.write("[{}] {}\n".format(self.prefix, line))
 
         self.buffer = lines[-1]
         self.src_stream.flush()
@@ -32,6 +33,7 @@ class PrefixedContext(context.Context):
     Wrapper class around a pyinvoke context adding a prefix to each lines
     outputed by ctx.run(..).
     """
+
     def __init__(self, ctx, prefix):
         super().__init__(ctx.config)
         self.prefix = prefix
@@ -41,14 +43,16 @@ class PrefixedContext(context.Context):
             *args,
             **kwargs,
             out_stream=PrefixedStream(sys.stdout, self.prefix),
-            err_stream=PrefixedStream(sys.stderr, self.prefix + ':ERR'),
+            err_stream=PrefixedStream(sys.stderr, self.prefix + ":ERR"),
         )
+
 
 def format_stdout(fun):
     """
     Wrapper decorator around a task adding its name to each line outputed by
     ctx.run(..).
     """
+
     @wraps(fun)
     def upgraded_fun(ctx, *args, **kwargs):
         ctx = PrefixedContext(ctx, fun.__name__)

--- a/import_data/tasks/format_stdout.py
+++ b/import_data/tasks/format_stdout.py
@@ -22,7 +22,7 @@ class PrefixedStream:
         lines = self.buffer.split("\n")
 
         for line in lines[:-1]:
-            self.src_stream.write("[{}] {}\n".format(self.prefix, line))
+            self.src_stream.write(f"[{self.prefix}] {line}\n")
 
         self.buffer = lines[-1]
         self.src_stream.flush()

--- a/import_data/tasks/lock.py
+++ b/import_data/tasks/lock.py
@@ -5,7 +5,7 @@ import fcntl
 class FileLock:
     def __init__(self, path):
         # Open the file and acquire a lock on the file before operating
-        self.file = open(path, 'a+')
+        self.file = open(path, "a+")
         # Get an exclusive lock (EX), non-blocking (NB)
         try:
             fcntl.flock(self.file, fcntl.LOCK_EX | fcntl.LOCK_NB)

--- a/import_data/tasks/osm_update.py
+++ b/import_data/tasks/osm_update.py
@@ -22,12 +22,12 @@ def log_error(msg):
 
 def format_file_size(size):
     if size > 1000000000:
-        return '{}GB'.format(size / 1000000000)
+        return "{}GB".format(size / 1000000000)
     elif size > 1000000:
-        return '{}MB'.format(size / 1000000)
+        return "{}MB".format(size / 1000000)
     elif size > 1000:
-        return '{}KB'.format(size / 1000)
-    return '{}B'.format(size)
+        return "{}KB".format(size / 1000)
+    return "{}B".format(size)
 
 
 def load_json(file_path):
@@ -44,10 +44,7 @@ def run_imposm_update(ctx, tileset, change_file, pg_connection):
     mapping_path = path.join(ctx.imposm_config_dir, tileset.mapping_filename)
 
     log("apply changes on OSM database")
-    log("{} file size is {}".format(
-        change_file,
-        format_file_size(os.path.getsize(change_file))
-    ))
+    log("{} file size is {}".format(change_file, format_file_size(os.path.getsize(change_file))))
 
     try:
         ctx.run(
@@ -84,12 +81,7 @@ def create_tiles_jobs(ctx, tileset_config, start_ts):
     # Get all tiles updated since start timestamp
     entries = "|".join(
         get_all_files(
-            path.join(
-                ctx.update_tiles_dir,
-                "expiretiles",
-                tileset_config.name
-            ),
-            start_ts,
+            path.join(ctx.update_tiles_dir, "expiretiles", tileset_config.name), start_ts,
         )
     )
 
@@ -104,7 +96,7 @@ def create_tiles_jobs(ctx, tileset_config, start_ts):
         tileset_name=tileset_config.name,
         from_zoom=UPDATE_TILES_FROM_ZOOM,
         before_zoom=UPDATE_TILES_BEFORE_ZOOM,
-        expired_tiles=entries
+        expired_tiles=entries,
     )
 
 
@@ -129,11 +121,16 @@ def osm_update(ctx, pg_connection, change_file):
     # Update db and tiles, only if changes file is not empty
     if os.path.getsize(change_file) != 0:
         # Imposm update for both tiles sources
-        run_imposm_update(ctx, ctx.tiles.tilesets.basemap, change_file=change_file, pg_connection=pg_connection)
-        run_imposm_update(ctx, ctx.tiles.tilesets.poi, change_file=change_file, pg_connection=pg_connection)
+        run_imposm_update(
+            ctx, ctx.tiles.tilesets.basemap, change_file=change_file, pg_connection=pg_connection
+        )
+        run_imposm_update(
+            ctx, ctx.tiles.tilesets.poi, change_file=change_file, pg_connection=pg_connection
+        )
 
         # We make the import here to prevent a circular dependency if put at the top.
         from .tasks import reindex_poi_geometries
+
         # Reindex geometries to avoid index bloat
         reindex_poi_geometries(ctx)
 
@@ -145,10 +142,11 @@ def osm_update(ctx, pg_connection, change_file):
     log("current location: {}".format(os.getcwd()))
     log("============")
     elapsed = int(datetime.now().timestamp()) - start_timestamp
-    log("osm_update duration: {}h{:02}m{:02}s".format(
-        elapsed // 3600,
-        elapsed % 3600 // 60,
-        elapsed % 60))
+    log(
+        "osm_update duration: {}h{:02}m{:02}s".format(
+            elapsed // 3600, elapsed % 3600 // 60, elapsed % 60
+        )
+    )
     log("osm_update successfully terminated!")
 
     return True

--- a/import_data/tasks/osm_update.py
+++ b/import_data/tasks/osm_update.py
@@ -13,21 +13,22 @@ def get_time_now():
 
 
 def log(msg):
-    print("[{}] {} :INFO: {}".format(get_time_now(), os.getpid(), msg))
+    print(f"[{get_time_now()}] {os.getpid()} :INFO: {msg}")
 
 
 def log_error(msg):
-    print("[{}] {} :ERROR: {}".format(get_time_now(), os.getpid(), msg))
+    print(f"[{get_time_now()}] {os.getpid()} :ERROR: {msg}")
 
 
 def format_file_size(size):
-    if size > 1000000000:
-        return "{}GB".format(size / 1000000000)
-    elif size > 1000000:
-        return "{}MB".format(size / 1000000)
-    elif size > 1000:
-        return "{}KB".format(size / 1000)
-    return "{}B".format(size)
+    prefixes = ["", "K", "M", "G", "T"]
+    i_prefix = 0
+
+    while i_prefix + 1 < len(prefixes) and size >= 1000:
+        i_prefix += 1
+        size /= 1024
+
+    return f"{size:.2f}{prefixes[i_prefix]}B"
 
 
 def load_json(file_path):
@@ -35,7 +36,7 @@ def load_json(file_path):
         with open(file_path) as json_file:
             return json.load(json_file)
     except Exception as err:
-        log_error("Couldn't parse JSON from `{}`: {}".format(file_path, err))
+        log_error(f"Couldn't parse JSON from `{file_path}`: {err}")
         raise
 
 
@@ -44,7 +45,7 @@ def run_imposm_update(ctx, tileset, change_file, pg_connection):
     mapping_path = path.join(ctx.imposm_config_dir, tileset.mapping_filename)
 
     log("apply changes on OSM database")
-    log("{} file size is {}".format(change_file, format_file_size(os.path.getsize(change_file))))
+    log(f"{change_file} file size is " + format_file_size(os.path.getsize(change_file)))
 
     try:
         ctx.run(
@@ -89,7 +90,7 @@ def create_tiles_jobs(ctx, tileset_config, start_ts):
         log("no expired tiles")
         return
 
-    log("file with tile to regenerate = {}".format(entries))
+    log(f"file with tile to regenerate = {entries}")
 
     generate_expired_tiles(
         ctx,
@@ -104,7 +105,7 @@ def check_settings(settings, keys):
     errors = 0
     for key in keys:
         if settings.get(key) is None:
-            log_error("Missing `{}` setting".format(key))
+            log_error(f"Missing `{key}` setting")
             errors += 1
     return errors == 0
 
@@ -113,10 +114,10 @@ def osm_update(ctx, pg_connection, change_file):
     start_timestamp = int(datetime.now().timestamp())
 
     log("new osm_update process started")
-    log("working into directory: {}".format(ctx.update_tiles_dir))
+    log(f"working into directory: {ctx.update_tiles_dir}")
 
     if not path.isfile(change_file):
-        raise Exception("Change file `{}` was not found.".format(change_file))
+        raise Exception(f"Change file `{change_file}` was not found.")
 
     # Update db and tiles, only if changes file is not empty
     if os.path.getsize(change_file) != 0:
@@ -139,14 +140,11 @@ def osm_update(ctx, pg_connection, change_file):
         create_tiles_jobs(ctx, ctx.tiles.tilesets.poi, start_ts=start_timestamp)
 
     log("============")
-    log("current location: {}".format(os.getcwd()))
+    log(f"current location: {os.getcwd()}")
     log("============")
     elapsed = int(datetime.now().timestamp()) - start_timestamp
-    log(
-        "osm_update duration: {}h{:02}m{:02}s".format(
-            elapsed // 3600, elapsed % 3600 // 60, elapsed % 60
-        )
-    )
+    hh, mm, ss = elapsed // 3600, elapsed % 3600 // 60, elapsed % 60
+    log(f"osm_update duration: {hh}h{mm:02}m{ss:02}s")
     log("osm_update successfully terminated!")
 
     return True

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -746,7 +746,7 @@ def check_if_folder_has_folders(folder, folders):
             folders.remove(f)
     if len(folders) > 0:
         for f in folders:
-            logging.error("'{}' should be present in {}".format(f, folder))
+            logging.error(f"'{f}' should be present in {folder}")
         return False
     return True
 

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -210,7 +210,7 @@ def get_osm_data(ctx):
 def _run_imposm_import(ctx, tileset_config):
     ctx.run(
         "time imposm3 import -write -diff -quiet -optimize -deployproduction -overwritecache"
-        f' -write --connection "{_pg_conn_str(ctx)}"'
+        f' --connection "{_pg_conn_str(ctx)}"'
         f" -read {ctx.osm.file}"
         f" -mapping {os.path.join(ctx.imposm_config_dir, tileset_config.mapping_filename)}"
         f" -diffdir {ctx.generated_files_dir}/diff/{tileset_config.name}"

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -52,9 +52,9 @@ def _pg_env(ctx):
     }
 
 
-def _pg_conn_str(ctx):
+def _pg_conn_str(ctx, db):
     pg = ctx.pg
-    return f"postgis://{pg.user}:{pg.password}@{pg.host}:{pg.port}/{pg.import_database}"
+    return f"postgis://{pg.user}:{pg.password}@{pg.host}:{pg.port}/{db}"
 
 
 def _open_sql_connection(ctx, db):
@@ -210,7 +210,7 @@ def get_osm_data(ctx):
 def _run_imposm_import(ctx, tileset_config):
     ctx.run(
         "time imposm3 import -write -diff -quiet -optimize -deployproduction -overwritecache"
-        f' --connection "{_pg_conn_str(ctx)}"'
+        f' --connection "{_pg_conn_str(ctx, ctx.pg.import_database)}"'
         f" -read {ctx.osm.file}"
         f" -mapping {os.path.join(ctx.imposm_config_dir, tileset_config.mapping_filename)}"
         f" -diffdir {ctx.generated_files_dir}/diff/{tileset_config.name}"
@@ -830,7 +830,7 @@ def run_osm_update(ctx):
 
         new_osm_timestamp = read_osm_timestamp(ctx, change_file_path)
 
-        osm_update(ctx, _pg_conn_str(ctx), change_file_path)
+        osm_update(ctx, _pg_conn_str(ctx, ctx.pg.database), change_file_path)
         write_new_state(ctx, new_osm_timestamp)
         os.remove(change_file_path)
 

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -39,7 +39,7 @@ def join(*futures):
     #       `run.done` is a set.
     for result in run.done:
         if result.exception() is not None:
-            raise result.exception()
+            raise Exception("concurrent task failed") from result.exception()
 
 
 def _pg_env(ctx):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 100
+target-version = ['py36']
+include = '''
+    exec.py
+  | /import_data/tasks/
+'''


### PR DESCRIPTION
Attempt to cleanup a bit existing python scripts, though my humble point of perception. 

### What changed 

 - Applied black formater and integration in the CI, like in Idunn
 - Tried to fix large string defined in `tasks.py` breaking the identation
 - Propagate the exceptions raised from concurrent tasks
 - Simplify `exec.py` (it lost ~100 lines of code, and may be more maintainable and understandable from my point of view?)