### PR TITLE
Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - DOCKER_IMAGE_PREFIX=qwantresearch/kartotherian
   matrix:
     - SERVICE=linter
+    - SERVICE=test
     - SERVICE=load_db
     - SERVICE=tilerator
     - SERVICE=kartotherian
@@ -25,6 +26,8 @@ script: >
     if [ "$SERVICE" == "linter" ]; then
         pip install --pre black
         black --diff --check .
+    elif [ "$SERVICE" == "test" ]; then
+        ./exec.py load-db --env INVOKE_WIKIDATA_STATS_ENABLED=0
     else
         export DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}_$SERVICE"
         docker build --label "org.label-schema.vcs-ref=$TRAVIS_COMMIT" -t $DOCKER_IMAGE -f ./$SERVICE/Dockerfile .

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,10 @@ script: >
         pip install --pre black
         black --diff --check .
     elif [ "$SERVICE" == "test" ]; then
-        ./exec.py --debug load-db --env INVOKE_WIKIDATA_STATS_ENABLED=0
+        ./exec.py --debug load-db \
+            --env INVOKE_WIKIDATA_STATS_ENABLED=0 \
+            --osm-file https://download.geofabrik.de/europe/monaco-latest.osm.pbf \
+            --tiles-coords "[[266, 186, 9]]"
         ./exec.py --debug test
     else
         export DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}_$SERVICE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script: >
             --env INVOKE_WIKIDATA_STATS_ENABLED=0 \
             --osm-file https://download.geofabrik.de/europe/monaco-latest.osm.pbf \
             --tiles-coords "[[266, 186, 9]]"
-        ./exec.py --debug test
+        ./exec.py --debug --no-build test
     else
         export DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}_$SERVICE"
         docker build --label "org.label-schema.vcs-ref=$TRAVIS_COMMIT" -t $DOCKER_IMAGE -f ./$SERVICE/Dockerfile .

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script: >
         pip install --pre black
         black --diff --check .
     elif [ "$SERVICE" == "test" ]; then
-        ./exec.py load-db --env INVOKE_WIKIDATA_STATS_ENABLED=0
+        ./exec.py --debug load-db --env INVOKE_WIKIDATA_STATS_ENABLED=0
+        ./exec.py --debug test
     else
         export DOCKER_IMAGE="${DOCKER_IMAGE_PREFIX}_$SERVICE"
         docker build --label "org.label-schema.vcs-ref=$TRAVIS_COMMIT" -t $DOCKER_IMAGE -f ./$SERVICE/Dockerfile .

--- a/exec.py
+++ b/exec.py
@@ -16,7 +16,7 @@ BUILD_COMMANDS = ["build", "kartotherian", "test"] + LOAD_DB_COMMANDS
 
 def exec_command(command, debug=False):
     if debug:
-        print("===>", " ".join(command), file=sys.stderr)
+        print("===>", " ".join(command), file=sys.stderr, flush=True)
 
     p = subprocess.Popen(command)
     p.wait()

--- a/exec.py
+++ b/exec.py
@@ -95,6 +95,7 @@ def build_argparser():
             ("load-db-france", "load data (tiles too) for the french country"),
             ("tileview", "run a map server which allows to get detailed tiles information"),
             ("update-tiles", "update the tiles data"),
+            ("stop", "stop kartotherian"),
             ("clean", "stop and remove running docker instances"),
             ("logs", "show docker logs (can be filtered with `--filter` option)"),
             ("test", "run tests on generated tiles and db"),
@@ -165,6 +166,9 @@ def main():
 
     if args.command == "update-tiles":
         docker_run(["load_db", "run-osm-update"], args.namespace, args.debug)
+
+    if args.command == "stop":
+        docker_exec(["stop"], args.namespace, args.debug)
 
     if args.command == "clean":
         docker_exec(["down", "-v"], args.namespace, args.debug)

--- a/exec.py
+++ b/exec.py
@@ -121,6 +121,14 @@ def build_argparser():
             """,
         )
 
+        subcommands[cmd].add_argument(
+            "--env",
+            "-e",
+            action="append",
+            default=[],
+            help="Set environement variable during docker run.",
+        )
+
     # `logs` specific parameters
 
     subcommands["logs"].add_argument(
@@ -141,12 +149,11 @@ def main():
         is_url = re.match("https?://.*", args.osm_file)
         file_key = "INVOKE_OSM_URL" if is_url else "INVOKE_OSM_FILE"
 
-        docker_run(
-            ["load_db"],
-            args.namespace,
-            args.debug,
-            env={file_key: args.osm_file, "INVOKE_TILES_COORDS": args.tiles_coords},
-        )
+        env = {arg.split("=")[0]: arg.split("=")[1] for arg in args.env}
+        env["INVOKE_TILES_COORDS"] = args.tiles_coords
+        env[file_key] = args.osm_file
+
+        docker_run(["load_db"], args.namespace, args.debug, env=env)
 
     if args.command == "tileview":
         docker_exec(["up", "-d", "tileview"], args.namespace, args.debug)

--- a/import_data/Pipfile.lock
+++ b/import_data/Pipfile.lock
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
-                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
             ],
-            "version": "==2019.9.11"
+            "version": "==2020.6.20"
         },
         "chardet": {
             "hashes": [
@@ -38,42 +38,39 @@
         },
         "graphviz": {
             "hashes": [
-                "sha256:241fb099e32b8e8c2acca747211c8237e40c0b89f24b1622860075d59f4c4b25",
-                "sha256:60acbeee346e8c14555821eab57dbf68a169e6c10bce40e83c1bf44f63a62a01"
+                "sha256:088562ef6e3dad5e8dde9389caf4a84f768e65dcaa08238cfcdf36d2b30ccf61",
+                "sha256:f5aad52a652c06825dcc5ee018d920fca26aef339386866094597fb3f2f222ce"
             ],
-            "version": "==0.13.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.14.1"
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
         "invoke": {
             "hashes": [
-                "sha256:c52274d2e8a6d64ef0d61093e1983268ea1fc0cd13facb9448c4ef0c9a7ac7da",
+                "sha256:93e12876d88130c8e0d7fd6618dd5387d6b36da55ad541481dfa5e001656f134",
                 "sha256:f4ec8a134c0122ea042c8912529f87652445d9f4de590b353d23f95bfa1f0efd",
-                "sha256:fc803a5c9052f15e63310aa81a43498d7c55542beb18564db88a9d75a176fa44"
+                "sha256:de3f23bfe669e3db1085789fd859eb8ca8e0c5d9c20811e2407fa042e8a5e15d",
+                "sha256:87b3ef9d72a1667e104f89b159eaf8a514dbf2f3576885b2bbdefe74c3fb2132",
+                "sha256:fc803a5c9052f15e63310aa81a43498d7c55542beb18564db88a9d75a176fa44",
+                "sha256:c52274d2e8a6d64ef0d61093e1983268ea1fc0cd13facb9448c4ef0c9a7ac7da"
             ],
             "index": "pypi",
-            "version": "==1.3.0"
-        },
-        "openmaptiles-tools": {
-            "hashes": [
-                "sha256:c10809e7df7025773960f0f9c6a35710069fdfe476991af8a95cde645bce0080",
-                "sha256:faa153e811ddb730af7980d4f884f11185935ae6926b87aa199c1b5380bfd15a"
-            ],
-            "index": "pypi",
-            "version": "==0.9.2"
+            "version": "==1.4.1"
         },
         "jinja2": {
             "hashes": [
-                "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f",
-                "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"
+                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
+                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
             "index": "pypi",
-            "version": "==2.10.3"
+            "version": "==2.11.2"
         },
         "markupsafe": {
             "hashes": [
@@ -81,13 +78,16 @@
                 "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
                 "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
                 "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
                 "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
                 "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
                 "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
                 "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
                 "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
                 "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
                 "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
                 "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
                 "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
                 "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
@@ -104,89 +104,101 @@
                 "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
                 "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
                 "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
-                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
+        },
+        "openmaptiles-tools": {
+            "hashes": [
+                "sha256:c10809e7df7025773960f0f9c6a35710069fdfe476991af8a95cde645bce0080",
+                "sha256:faa153e811ddb730af7980d4f884f11185935ae6926b87aa199c1b5380bfd15a"
+            ],
+            "index": "pypi",
+            "version": "==0.9.2"
         },
         "osmium": {
             "hashes": [
-                "sha256:0178bc3dd46fd304b0a22a951df1a116d37bb0d4869bbe6c566ce1abf39be7e5",
-                "sha256:07f6315af25fb496125d140151e317de0486ddc20254616d2347cd5537091e07",
-                "sha256:090fbcf394b76c7a4e967f55977a1491efaf3276b4a27ec1262cfd13073eb497",
-                "sha256:0b798022ddb598ffa8c5baf979cc0fe275a9419dfdf3ca21a92ede596f99bae2",
-                "sha256:2170516d9c3c95432ea725ac4a0dca590fb263f80b6fc3f361a3d30eb9c41f28",
-                "sha256:35d9ea62e0016466eece390792644192d45dbf12c70637d293b8be408c2390cd",
-                "sha256:455dcd129819b1c47cfcb7c676e362c07b32dc5558bf16eddd0333f8899e331e",
-                "sha256:5545722ce2ead2c1e634ef23e26b694fe06f5768006195762f14ab6496fb72ed",
-                "sha256:68d8a9bab38657362d55ec0c2878acc40a74f4602e263c1c3b75bdfe8135c59c",
-                "sha256:69fd3f0da9ecb3a041075bd84702ef9237c67c09f1a0b6defb00bbb727249259",
-                "sha256:712910c5472726bb62a6e043179697e0a52ebb09b7e4e23dbf4a8d0e31c90e11",
-                "sha256:82d84dbfe437546aad4e427d9b667eb4575b35100e8ff60fd1f0752522126211",
-                "sha256:8475e8dc2186d0817b0254e35f502582592b8b44cd0a9478cbecd6602791ff50",
-                "sha256:851491cddb07e7cf25b74a29e7ceca9c0eac74c45d0a033e6085820e830e1f32",
-                "sha256:8ae2ce116bec61b2e51b181f61214fba06ec25ccd4d51cb42386b8b4b73ccd91",
-                "sha256:8ea713709267a461eaf2c6544f4fe358312558e7448480f5fd0c3fef023e996d",
-                "sha256:b7f774794fac9df16ad745035aa61e28a00c5a75bed3483fa77f67e34dc61920",
-                "sha256:bb40e3e468b47e01f759a1c5de9e5429224ca6b8fe09f690c169480afc7ea840",
-                "sha256:bc67305d09f391d735883efea870c37a3aa2dabf32530026a409eb506b52a2f0",
-                "sha256:bef1b37772b39a438c5b2e65dbc1f3417ef2a8ade829ef1f6f0179431c5bcb7c",
-                "sha256:df9bded041a099a72bc3bfb3732df93c36f96801c2706721d1d8623419e64321",
-                "sha256:e0d4a1049a5bf8445c6e8c6cbc8f247795322870a32ca63f5fdec24cbcc973c2"
+                "sha256:04e2f3380525c9b100d7c9350e107ae0d75c378c4c36d17cc4999c5952b33960",
+                "sha256:0a5e9cccd9c376ab31fe79cdb1efcd1eb8175e7ff74a1f7ac218bd084d1a819d",
+                "sha256:32e0b94c9a6f24c3f86787a5e23d7289c00467a19d13ff2552feb2810d8b76c3",
+                "sha256:396557cc44f9655419060fb56623822b64af3f835df1f35ca0bb5aad2b5f33fe",
+                "sha256:44cd17932ef17c1c749ff5585a76e68b4615bfbe94828b7765bdebb39dfb2d85",
+                "sha256:6909a93173acd4111cc179bd7317e8a4e656c3b7b1a9041c5a5a8fcd01dbc3b5",
+                "sha256:7638dd47f667ab2f18e0092036851e4ead4a47fb5840ff138e20c02bd47d14d7",
+                "sha256:7c3782400d001229302bdffd6f410c460b270aef29a4a58c45fd479c897825b6",
+                "sha256:8451c8ebdb39b7f3d5bc038c0230f592d4dffa50ec6baef64ee8baa72e814e8a",
+                "sha256:84a7259ab1c2a37b399cfd53b82c402daf8df611ce9223dc443ccf3142b97223",
+                "sha256:8bf205bed661aa0ab7cb39f00981ced6b1f46d923c5aec246e89616b45f64dd2",
+                "sha256:97de71233b4741992008ca49e77c0a92999e9077cec9d6511759ba5d55faedde",
+                "sha256:a4a2a7c55696ad32f809dfb48f0eca1acffc6d447063d2062aaca6d6f9a26946",
+                "sha256:a60445b2122e159d7775d57f4958191ea5a32395b289c91156841ef04bdc2182",
+                "sha256:a8f4ecebe1d536ab7cdd02fa9f82ff745dd4aa8ed478ccf588f586b4c4af38a9",
+                "sha256:c3526f17eeb58eda0525888542ae14586745b0faaaf00dca2ccf2d376b75899f",
+                "sha256:c85c2bc37b118b93dc8eb6c141bf415eff34c35084613be29ced3b969b49c7f6",
+                "sha256:ce18818b7260113fcedb54e3167da0e9a07723a92f23a594318086d8c09645df",
+                "sha256:cf78640c5cd9b8e76ee37b5c0522c5130469d3db26ffdfd54e8fb751477787f5",
+                "sha256:d5da39de1c00d0c0ef8771df29424abb8bdc3fe093641c1df7448f0a22266f28",
+                "sha256:e25a2f8f495ff7d96c1c3a4c636ea5aa5176b58d5323350f913b30a6a1b67159",
+                "sha256:ede6fed48da8512415a4a895c2ded2777dacddfacc1b342f7938aa4271c97bd1",
+                "sha256:f247a74c6a02016c7f3749f5fc6fad3abaa5c7874ae2be9516ef1649dc276792",
+                "sha256:fe43969f2fb021051c2c202c28bd42bd7453f3f41d5d2499126b16437bb52f63"
             ],
             "index": "pypi",
-            "version": "==2.15.3"
+            "version": "==3.0.1"
         },
         "psycopg2": {
             "hashes": [
-                "sha256:4212ca404c4445dc5746c0d68db27d2cbfb87b523fe233dc84ecd24062e35677",
-                "sha256:47fc642bf6f427805daf52d6e52619fe0637648fe27017062d898f3bf891419d",
-                "sha256:72772181d9bad1fa349792a1e7384dde56742c14af2b9986013eb94a240f005b",
-                "sha256:8396be6e5ff844282d4d49b81631772f80dabae5658d432202faf101f5283b7c",
-                "sha256:893c11064b347b24ecdd277a094413e1954f8a4e8cdaf7ffbe7ca3db87c103f0",
-                "sha256:92a07dfd4d7c325dd177548c4134052d4842222833576c8391aab6f74038fc3f",
-                "sha256:965c4c93e33e6984d8031f74e51227bd755376a9df6993774fd5b6fb3288b1f4",
-                "sha256:9ab75e0b2820880ae24b7136c4d230383e07db014456a476d096591172569c38",
-                "sha256:b0845e3bdd4aa18dc2f9b6fb78fbd3d9d371ad167fd6d1b7ad01c0a6cdad4fc6",
-                "sha256:dca2d7203f0dfce8ea4b3efd668f8ea65cd2b35112638e488a4c12594015f67b",
-                "sha256:ed686e5926929887e2c7ae0a700e32c6129abb798b4ad2b846e933de21508151",
-                "sha256:ef6df7e14698e79c59c7ee7cf94cd62e5b869db369ed4b1b8f7b729ea825712a",
-                "sha256:f898e5cc0a662a9e12bde6f931263a1bbd350cfb18e1d5336a12927851825bb6"
+                "sha256:132efc7ee46a763e68a815f4d26223d9c679953cd190f1f218187cb60decf535",
+                "sha256:2327bf42c1744a434ed8ed0bbaa9168cac7ee5a22a9001f6fc85c33b8a4a14b7",
+                "sha256:27c633f2d5db0fc27b51f1b08f410715b59fa3802987aec91aeb8f562724e95c",
+                "sha256:2c0afb40cfb4d53487ee2ebe128649028c9a78d2476d14a67781e45dc287f080",
+                "sha256:2df2bf1b87305bd95eb3ac666ee1f00a9c83d10927b8144e8e39644218f4cf81",
+                "sha256:440a3ea2c955e89321a138eb7582aa1d22fe286c7d65e26a2c5411af0a88ae72",
+                "sha256:6a471d4d2a6f14c97a882e8d3124869bc623f3df6177eefe02994ea41fd45b52",
+                "sha256:6b306dae53ec7f4f67a10942cf8ac85de930ea90e9903e2df4001f69b7833f7e",
+                "sha256:a0984ff49e176062fcdc8a5a2a670c9bb1704a2f69548bce8f8a7bad41c661bf",
+                "sha256:ac5b23d0199c012ad91ed1bbb971b7666da651c6371529b1be8cbe2a7bf3c3a9",
+                "sha256:acf56d564e443e3dea152efe972b1434058244298a94348fc518d6dd6a9fb0bb",
+                "sha256:d3b29d717d39d3580efd760a9a46a7418408acebbb784717c90d708c9ed5f055",
+                "sha256:f7d46240f7a1ae1dd95aab38bd74f7428d46531f69219954266d669da60c0818"
             ],
             "index": "pypi",
-            "version": "==2.8.4"
+            "version": "==2.8.5"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
-                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
-                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
-                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
-                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
-                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
-                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
-                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
-                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
-                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
-                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
-                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
-                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
+                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
+                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
+                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
+                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
+                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
+                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
+                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
+                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
+                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
+                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
+                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
             ],
-            "version": "==5.1.2"
+            "version": "==5.3.1"
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
+                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
             ],
             "index": "pypi",
-            "version": "==2.22.0"
+            "version": "==2.24.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
+                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
-            "version": "==1.25.7"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.25.10"
         }
     },
     "develop": {}

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -867,7 +867,7 @@ def test_postgres_loaded(ctx):
 
     def poi_exists(name):
         raw_res = _execute_sql(ctx, f"SELECT COUNT(*) FROM {name}", additional_options="-tA",)
-        return int(raw_res.stdout.strip()) > 0
+        return int(raw_res.stdout.strip() or "0") > 0
 
     count_exists = sum(poi_exists(name) for name in tables)
     print(f"[test_poi_loaded] {count_exists}/{len(tables)} tables filled")

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -849,7 +849,6 @@ def test_tile_generation(ctx):
         return {
             "complete": stats["completeCount"],
             "failed": stats["failedCount"],
-            "duration": stats["workTime"] / 60000,
         }
 
     while not get_tilerator_result():


### PR DESCRIPTION
Adds the following tests to the CI:

 1. run successfully task `load-db`
 2. tile generation for Monaco area ends with no failure
 3. tables `osm_poi_*` are not empty

I'm not very inspired for more tests but don't hesitate to ask for more :)

There is some secondary modifications (and side effects):

 - add a `--env` parameter in `exec.py` to set environment variables in `load_db` (handy to override some `invoke` parameter)
 - add a `--no-build` parameter to run a command without rebuilding the images (it takes a few seconds even when using Docker's cache)
 - add a `stop` subcommand in `exec.py` for convenience
 - remove `build` subcommand that was actually currently doing the same thing as `kartotherian`
 - hide `psql`'s output when stdout is actually used for a computation
 - update python dependancies in `load_db`