### PR TITLE
exec.py: do not start images before cleaning

### DIFF
--- a/exec.py
+++ b/exec.py
@@ -145,12 +145,11 @@ def main():
     parser = build_argparser()
     args = parser.parse_args()
 
-    up_cmd = ["up", "-d"]
-
-    if args.build:
-        up_cmd.append("--build")
-
-    docker_exec(up_cmd, args.namespace, args.debug)
+    if args.command == "clean":
+        docker_exec(["down", "-v"], args.namespace, args.debug)
+    else:
+        up_cmd = ["up", "-d"] + (["--build"] if args.build else [])
+        docker_exec(up_cmd, args.namespace, args.debug)
 
     if args.command in LOAD_DB_COMMANDS:
         is_url = re.match("https?://.*", args.osm_file)
@@ -170,9 +169,6 @@ def main():
 
     if args.command == "stop":
         docker_exec(["stop"], args.namespace, args.debug)
-
-    if args.command == "clean":
-        docker_exec(["down", "-v"], args.namespace, args.debug)
 
     if args.command == "logs":
         docker_exec(["logs"], args.namespace, args.debug)

--- a/import_data/import-wikidata/wikidata_functions.sql
+++ b/import_data/import-wikidata/wikidata_functions.sql
@@ -19,11 +19,11 @@ RETURNS REAL AS $$
         -- Lower limit to the number of view of a Wikipedia page to consider it
         -- relevant. If a page generates less views than this limit, the output
         -- value will be computed as if this page doesn't exist.
-        min_views CONSTANT REAL := {{ min_views }};
+        min_views CONSTANT REAL := {{ min_views }};
 
         -- Upper limit to the number of views of a Wikipedia page. Pages with a
         -- greater number of views will have a weight of 1.
-        max_views CONSTANT REAL := {{ max_views }};
+        max_views CONSTANT REAL := {{ max_views }};
 
         views_count REAL;
     BEGIN

--- a/kubernetes/templates/load_db.job.yaml
+++ b/kubernetes/templates/load_db.job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       nodeSelector:
         # This job needs to run on a specific node that
-        # will persist imposm 'cache' and 'diff' folders,
+        # will persist imposm 'cache' and 'diff' folders,
         # and on which osm_update is defined as a cron job.
         maps-pg-importer: "true"
       restartPolicy: Never


### PR DESCRIPTION
Fix a slightly annoying behavior introduced in https://github.com/QwantResearch/kartotherian_docker/pull/117.

When running  `./exec.py clean`, the script would first call `docker-compose up` (which waits until all docker images are running), then call `./exec.py down -v` (which will have to wait for all images to be stopped again).

(I also removed a few unbreakable spaces in other files)