### PR TITLE
Update to latest openmaptiles/postgis image, including postgis 3.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     # Custom image maintained by openmaptiles in https://github.com/openmaptiles/openmaptiles-tools
     # Based on postgres:9.6 and includes PostGIS and osml10n extensions
-    image: openmaptiles/postgis:1b0b981@sha256:f56869440250a81b15673ec7b9cc1729fc75b7dfaf8763ab09c5ea8d785ed639
+    image: openmaptiles/postgis:c310d1a@sha256:6d5156102748a134aa45a5feefc68b7178c8856952170fc55dd3cbbe165ce94c
     volumes:
       - "pgdata:/var/lib/postgresql/data"
     environment:

--- a/import_data/invoke.yaml
+++ b/import_data/invoke.yaml
@@ -13,6 +13,9 @@ generated_files_dir: /data/imposm
 data_dir: /data
 update_tiles_dir: /data/update_tiles_data
 
+imposm:
+  optimize: True # Pass -optimize option to imposm commands
+
 ################################################
 # Data sources
 

--- a/import_data/sql-overrides/osml10n_overrides.sql
+++ b/import_data/sql-overrides/osml10n_overrides.sql
@@ -1,0 +1,31 @@
+/*
+    Disable Kanji transliteration (produces invalid utf8)
+*/
+CREATE OR REPLACE FUNCTION osml10n_kanji_transcript(text) RETURNS text AS $$
+    SELECT NULL::text
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+
+
+/*
+    Override get_country: the original function provided by mapnik-german-l10n is too slow
+    # See https://github.com/giggls/mapnik-german-l10n/issues/54 for more details;
+    # the issue also mentions an alternative fix, not yet available on the latest release (v2.5.9)
+*/
+CREATE OR REPLACE FUNCTION osml10n_get_country(feature geometry)
+    RETURNS text
+    LANGUAGE plpgsql
+    STABLE PARALLEL SAFE STRICT
+AS $function$
+    DECLARE
+        transformed_feature geometry;
+        country text;
+    BEGIN
+        transformed_feature := st_centroid(st_transform(feature,4326));
+        SELECT country_code INTO country
+        FROM country_osm_grid
+        WHERE st_contains(geometry, transformed_feature)
+        ORDER BY area
+        LIMIT 1;
+    RETURN country;
+    END;
+$function$;

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -247,6 +247,34 @@ def run_sql_script(ctx):
         """,
     )
 
+    # override get_country: the original function provided by mapnik-german-l10n is too slow
+    # See https://github.com/giggls/mapnik-german-l10n/issues/54 for more details;
+    # the issue also mentions an alternative fix, not yet available on the latest release (v2.5.9)
+    _execute_sql(
+        ctx,
+        db=ctx.pg.import_database,
+        sql="""
+            CREATE OR REPLACE FUNCTION osml10n_get_country(feature geometry)
+                RETURNS text
+                LANGUAGE plpgsql
+                STABLE PARALLEL SAFE STRICT
+            AS $function$
+                DECLARE
+                    transformed_feature geometry;
+                    country text;
+                BEGIN
+                    transformed_feature := st_centroid(st_transform(feature,4326));
+                    SELECT country_code INTO country
+                    FROM country_osm_grid
+                    WHERE st_contains(geometry, transformed_feature)
+                    ORDER BY area
+                    LIMIT 1;
+                RETURN country;
+                END;
+            $function$;
+        """,
+    )
+
     # load language-related functions
     _run_sql_script(ctx, "import-sql/language.sql")
 

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -213,7 +213,8 @@ def get_osm_data(ctx):
 
 def _run_imposm_import(ctx, tileset_config):
     ctx.run(
-        "time imposm3 import -write -diff -quiet -optimize -deployproduction -overwritecache"
+        "time imposm3 import -write -diff -quiet -deployproduction -overwritecache"
+        f' {"-optimize" if ctx.imposm.optimize else ""}'
         f' --connection "{_pg_conn_str(ctx, ctx.pg.import_database)}"'
         f" -read {ctx.osm.file}"
         f" -mapping {os.path.join(ctx.imposm_config_dir, tileset_config.mapping_filename)}"

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -236,44 +236,8 @@ def load_poi(ctx):
 
 @task
 def run_sql_script(ctx):
-    # disable Kanji transliteration (produces invalid utf8)
-    _execute_sql(
-        ctx,
-        db=ctx.pg.import_database,
-        sql="""
-            CREATE OR REPLACE FUNCTION osml10n_kanji_transcript(text) RETURNS text AS $$
-                SELECT NULL::text
-            $$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-        """,
-    )
-
-    # override get_country: the original function provided by mapnik-german-l10n is too slow
-    # See https://github.com/giggls/mapnik-german-l10n/issues/54 for more details;
-    # the issue also mentions an alternative fix, not yet available on the latest release (v2.5.9)
-    _execute_sql(
-        ctx,
-        db=ctx.pg.import_database,
-        sql="""
-            CREATE OR REPLACE FUNCTION osml10n_get_country(feature geometry)
-                RETURNS text
-                LANGUAGE plpgsql
-                STABLE PARALLEL SAFE STRICT
-            AS $function$
-                DECLARE
-                    transformed_feature geometry;
-                    country text;
-                BEGIN
-                    transformed_feature := st_centroid(st_transform(feature,4326));
-                    SELECT country_code INTO country
-                    FROM country_osm_grid
-                    WHERE st_contains(geometry, transformed_feature)
-                    ORDER BY area
-                    LIMIT 1;
-                RETURN country;
-                END;
-            $function$;
-        """,
-    )
+    # osml10n fixes
+    _run_sql_script(ctx, "sql-overrides/osml10n_overrides.sql")
 
     # load language-related functions
     _run_sql_script(ctx, "import-sql/language.sql")

--- a/load_db/Dockerfile
+++ b/load_db/Dockerfile
@@ -13,10 +13,10 @@ RUN apt-get update && \
         postgresql-client \
         jq \
     && rm -rf /var/lib/apt/lists/* \
-# install imposm 0.10.0 (custom release, waiting for https://github.com/omniscale/imposm3/pull/206 to be merged)
-    && wget https://github.com/amatissart/imposm3/releases/download/v0.10.0-qwant.0/imposm-0.10.0-qwant.0-linux-x86-64.tar.gz \
-    && tar xvfz imposm-0.10.0-qwant.0-linux-x86-64.tar.gz \
-    && ln -sf /imposm-0.10.0-qwant.0-linux-x86-64/imposm /usr/local/bin/imposm3 \
+# install imposm 0.11.0 (custom release, waiting for https://github.com/omniscale/imposm3/pull/206 to be merged)
+    && wget https://github.com/amatissart/imposm3/releases/download/v0.11.0-qwant.0/imposm-0.11.0-qwant.0-linux-x86-64.tar.gz \
+    && tar xvfz imposm-0.11.0-qwant.0-linux-x86-64.tar.gz \
+    && ln -sf /imposm-0.11.0-qwant.0-linux-x86-64/imposm /usr/local/bin/imposm3 \
     && wget -O /usr/local/bin/pgfutter https://github.com/lukasmartinelli/pgfutter/releases/download/v1.1/pgfutter_linux_amd64 \
     && chmod +x /usr/local/bin/pgfutter \
     && pip install pipenv==2018.11.26


### PR DESCRIPTION
Upgrade to latest openmaptiles/postgis image, to work around with slow `CLUSTER` commands during imposm optimization process.

A few cascading changes following this update:
 * `-optimize` is now optional in imposm commands, to make future debugging easier. Still enabled by default
 * The new openmaptiles/postgis images comes with an upgrade to mapnik-german-osml10n v2.5.9 that includes an performance regression (see https://github.com/giggls/mapnik-german-l10n/issues/54) 
  The function `osml10n_get_country` needs to be overridden.
 * imposm3 v0.10 -> v0.11 because of an incompatibility with PostGIS 3.0 (see https://github.com/omniscale/imposm3/pull/248)