### PR TITLE
import_data: increase gap between lower and higher weights

### DIFF
--- a/import_data/import-wikidata/wikidata_functions.sql
+++ b/import_data/import-wikidata/wikidata_functions.sql
@@ -40,11 +40,19 @@ RETURNS REAL AS $$
             END;
         RETURN CASE
             WHEN views_count > min_views AND max_views - min_views > 1 THEN
-                0.5 + 0.5 * LOG(LEAST(max_views, views_count) - min_views)
-                             / LOG(max_views - min_views)
+                POWER(
+                    0.5 + 0.5
+                            * LOG(LEAST(max_views, views_count) - min_views)
+                            / LOG(max_views - min_views),
+                    3
+                )
             WHEN name <> '' THEN
-                0.5 * (
-                    1 - poi_class_rank(poi_class(subclass, mapping_key))::real / max_rank
+                POWER(
+                    0.5 * (
+                        1 - poi_class_rank(poi_class(subclass, mapping_key))::real
+                              / max_rank
+                    ),
+                    3
                 )
             ELSE
                 0.0

--- a/import_data/import-wikidata/wikidata_functions.sql
+++ b/import_data/import-wikidata/wikidata_functions.sql
@@ -25,6 +25,9 @@ RETURNS REAL AS $$
         -- greater number of views will have a weight of 1.
         max_views CONSTANT REAL := {{ max_views }};
 
+        -- Exponent used to increase importance of very well-known POIs.
+        weight_exponent CONSTANT REAL := {{ weight_exponent }};
+
         views_count REAL;
     BEGIN
         SELECT INTO views_count
@@ -44,7 +47,7 @@ RETURNS REAL AS $$
                     0.5 + 0.5
                             * LOG(LEAST(max_views, views_count) - min_views)
                             / LOG(max_views - min_views),
-                    3
+                    weight_exponent
                 )
             WHEN name <> '' THEN
                 POWER(
@@ -52,7 +55,7 @@ RETURNS REAL AS $$
                         1 - poi_class_rank(poi_class(subclass, mapping_key))::real
                               / max_rank
                     ),
-                    3
+                    weight_exponent
                 )
             ELSE
                 0.0

--- a/import_data/invoke.yaml
+++ b/import_data/invoke.yaml
@@ -50,6 +50,7 @@ wikidata:
     url: https://github.com/QwantResearch/wikimedia-dumps/releases/download/082019-102019/stats.csv.gz
     file: stats.csv.gz
     table: wm_stats
+    poi_weight_exponent: "3.0"
 
   labels:
     enabled: false

--- a/import_data/tasks/tasks.py
+++ b/import_data/tasks/tasks.py
@@ -452,6 +452,7 @@ def override_wikidata_weight_functions(ctx):
     params = {
         "min_views": compute_views_percentile(0.1),
         "max_views": compute_views_percentile(0.999),
+        "weight_exponent": ctx.wikidata.stats.poi_weight_exponent,
     }
 
     _run_sql_script(ctx, "import-wikidata/wikidata_functions.sql", template_params=params)


### PR DESCRIPTION
Apply a cube function to the weight computed for the POIs.

The goal is to increase visibility of very known POIs. This change seems to fix some very obvious example such as "Le Louvre", but has no effect on others (eg. Opera in Paris where the train station is famous enough to often being put first).

This PR cannot affect tiles as the order in weights is preserved.