### PR TITLE
Use imposm3 release from Qwant fork instead of personal repo

### DIFF
--- a/load_db/Dockerfile
+++ b/load_db/Dockerfile
@@ -15,9 +15,9 @@ RUN apt-get update && \
         jq \
     && rm -rf /var/lib/apt/lists/* \
 # install imposm 0.11.0 (custom release, waiting for https://github.com/omniscale/imposm3/pull/206 to be merged)
-    && wget https://github.com/amatissart/imposm3/releases/download/v0.11.0-qwant.0/imposm-0.11.0-qwant.0-linux-x86-64.tar.gz \
-    && tar xvfz imposm-0.11.0-qwant.0-linux-x86-64.tar.gz \
-    && ln -sf /imposm-0.11.0-qwant.0-linux-x86-64/imposm /usr/local/bin/imposm3 \
+    && wget https://github.com/qwant/imposm3/releases/download/v0.11.0-qwant.1/imposm-0.11.0-qwant.1-linux-x86-64.tar.gz \
+    && tar xvfz imposm-0.11.0-qwant.1-linux-x86-64.tar.gz \
+    && ln -sf /imposm-0.11.0-qwant.1-linux-x86-64/imposm /usr/local/bin/imposm3 \
     && wget -O /usr/local/bin/pgfutter https://github.com/lukasmartinelli/pgfutter/releases/download/v1.1/pgfutter_linux_amd64 \
     && chmod +x /usr/local/bin/pgfutter \
     && pip install pipenv==2018.11.26


### PR DESCRIPTION
The release has been built by GitHub actions, on branch `qwant` (tag: `v0.11.0-qwant.1`)

Branch: https://github.com/Qwant/imposm3/tree/qwant
Release: https://github.com/Qwant/imposm3/releases/tag/v0.11.0-qwant.1
